### PR TITLE
Bundle creation and consumption specs

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -58,8 +58,7 @@ ${ENTRYPOINT} sign-bundle --bundle FILE FILE
 #### Signature and certificate flow
 
 ```console
-${ENTRYPOINT} verify --signature FILE --certificate FILE
---certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
+${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |
@@ -73,8 +72,7 @@ ${ENTRYPOINT} verify --signature FILE --certificate FILE
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY
---certificate-oidc-issuer URL FILE
+${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -30,6 +30,8 @@ templates below.
 
 ### Sign
 
+#### Signature and certificate flow
+
 ```console
 ${ENTRYPOINT} sign --signature FILE --certificate FILE FILE
 ```
@@ -40,16 +42,44 @@ ${ENTRYPOINT} sign --signature FILE --certificate FILE FILE
 | `--certificate FILE` | The path to write the signing certificate to |
 | `FILE` | The artifact to sign |
 
-### Verify
+#### Bundle flow
 
 ```console
-${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-oidc-issuer URL FILE
+${ENTRYPOINT} sign-bundle --bundle FILE FILE
+```
+
+| Option | Description |
+| --- | --- |
+| `--bundle FILE` | The path to write the bundle to |
+| `FILE` | The artifact to sign |
+
+### Verify
+
+#### Signature and certificate flow
+
+```console
+${ENTRYPOINT} verify --signature FILE --certificate FILE
+--certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |
 | --- | --- |
 | `--signature FILE` | The path to the signature to verify |
 | `--certificate FILE` | The path to the signing certificate to verify |
+| `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
+| `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
+| `FILE` | The path to the artifact to verify |
+
+#### Bundle flow
+
+```console
+${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY
+--certificate-oidc-issuer URL FILE
+```
+
+| Option | Description |
+| --- | --- |
+| `--bundle FILE` | The path to the Sigstore bundle to verify |
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
 | `FILE` | The path to the artifact to verify |


### PR DESCRIPTION
Specifies bundle creation and consumption standards by:

- adding `sign-bundle` and `verify-bundle` subcommands;
- adding the `--bundle` flag that specifies the bundle to output or verify from.

I'm unsure of if we want to have separate `sign-bundle` and `verify-bundle` subcommands, as I mentioned in https://github.com/sigstore/sigstore-conformance/issues/65#issuecomment-1513638198. I can remove these subcommands and make some flags optional if we feel that approach is better.

Resolves #51.