### PR TITLE
workflows: pin python version to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: lint
         run: make lint

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
       - name: install sigstore-python
         run: pip install sigstore
       - name: conformance test sigstore-python


### PR DESCRIPTION
The changeset for #65 depends on Python 3.8 features, which causes issues with the CI workflow pinned on 3.7: https://github.com/trail-of-forks/sigstore-conformance/actions/runs/4747768731/jobs/8433107457

To fix that issue, this changeset pins both the conformance testing workflow and the CI workflow to a consistent version of Python.