### PR TITLE
Basic bundle tests

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -58,8 +58,7 @@ ${ENTRYPOINT} sign-bundle --bundle FILE FILE
 #### Signature and certificate flow
 
 ```console
-${ENTRYPOINT} verify --signature FILE --certificate FILE
---certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
+${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |
@@ -73,8 +72,7 @@ ${ENTRYPOINT} verify --signature FILE --certificate FILE
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY
---certificate-oidc-issuer URL FILE
+${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -30,6 +30,8 @@ templates below.
 
 ### Sign
 
+#### Signature and certificate flow
+
 ```console
 ${ENTRYPOINT} sign --signature FILE --certificate FILE FILE
 ```
@@ -40,16 +42,44 @@ ${ENTRYPOINT} sign --signature FILE --certificate FILE FILE
 | `--certificate FILE` | The path to write the signing certificate to |
 | `FILE` | The artifact to sign |
 
-### Verify
+#### Bundle flow
 
 ```console
-${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-oidc-issuer URL FILE
+${ENTRYPOINT} sign-bundle --bundle FILE FILE
+```
+
+| Option | Description |
+| --- | --- |
+| `--bundle FILE` | The path to write the bundle to |
+| `FILE` | The artifact to sign |
+
+### Verify
+
+#### Signature and certificate flow
+
+```console
+${ENTRYPOINT} verify --signature FILE --certificate FILE
+--certificate-identity IDENTITY --certificate-oidc-issuer URL FILE
 ```
 
 | Option | Description |
 | --- | --- |
 | `--signature FILE` | The path to the signature to verify |
 | `--certificate FILE` | The path to the signing certificate to verify |
+| `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
+| `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
+| `FILE` | The path to the artifact to verify |
+
+#### Bundle flow
+
+```console
+${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY
+--certificate-oidc-issuer URL FILE
+```
+
+| Option | Description |
+| --- | --- |
+| `--bundle FILE` | The path to the Sigstore bundle to verify |
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
 | `FILE` | The path to the artifact to verify |

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -46,7 +46,7 @@ ${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FI
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} sign-bundle --bundle FILE FILE
+${ENTRYPOINT} sign-bundle --identity-token TOKEN --bundle FILE FILE
 ```
 
 | Option | Description |

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -21,9 +21,9 @@ ARG_REPLACEMENTS = {
 fixed_args = sys.argv[1:]
 
 # Substitute incompatible subcommands.
-subcmd = fixed_args[1]
+subcmd = fixed_args[0]
 if subcmd in SUBCMD_REPLACEMENTS:
-    fixed_args[1] = SUBCMD_REPLACEMENTS[subcmd]
+    fixed_args[0] = SUBCMD_REPLACEMENTS[subcmd]
 
 # Replace incompatible flags.
 fixed_args = [

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -7,6 +7,11 @@ A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `s
 import subprocess
 import sys
 
+SUBCMD_REPLACEMENTS = {
+    "sign-bundle": "sign",
+    "verify-bundle": "verify",
+}
+
 ARG_REPLACEMENTS = {
     "--certificate-identity": "--cert-identity",
     "--certificate-oidc-issuer": "--cert-oidc-issuer",
@@ -14,6 +19,11 @@ ARG_REPLACEMENTS = {
 
 # Trim the script name.
 fixed_args = sys.argv[1:]
+
+# Substitute incompatible subcommands.
+subcmd = fixed_args[1]
+if subcmd in ARG_REPLACEMENTS:
+    fixed_args[1] = SUBCMD_REPLACEMENTS[subcmd]
 
 # Replace incompatible flags.
 fixed_args = [

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -22,7 +22,7 @@ fixed_args = sys.argv[1:]
 
 # Substitute incompatible subcommands.
 subcmd = fixed_args[1]
-if subcmd in ARG_REPLACEMENTS:
+if subcmd in SUBCMD_REPLACEMENTS:
     fixed_args[1] = SUBCMD_REPLACEMENTS[subcmd]
 
 # Replace incompatible flags.

--- a/test/client.py
+++ b/test/client.py
@@ -15,7 +15,7 @@ CERTIFICATE_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 class VerificationMaterials:
     """
     A wrapper around verification materials. Materials can be either bundles
-    or signatures and certificates.
+    or detached pairs of signatures and certificates.
     """
 
     @classmethod

--- a/test/client.py
+++ b/test/client.py
@@ -142,7 +142,9 @@ class SigstoreClient:
         )
 
     @sign.register
-    def _sign_for_bundle(self, materials: BundleMaterials, artifact: os.PathLike) -> None:
+    def _sign_for_bundle(
+        self, materials: BundleMaterials, artifact: os.PathLike
+    ) -> None:
         """
         Sign an artifact with the Sigstore client, producing a bundle.
 
@@ -204,7 +206,9 @@ class SigstoreClient:
         )
 
     @verify.register
-    def _verify_for_bundle(self, materials: BundleMaterials, artifact: os.PathLike) -> None:
+    def _verify_for_bundle(
+        self, materials: BundleMaterials, artifact: os.PathLike
+    ) -> None:
         """
         Verify an artifact given a bundle with the Sigstore client.
 

--- a/test/client.py
+++ b/test/client.py
@@ -29,7 +29,7 @@ class VerificationMaterials:
 
         raise NotImplementedError
 
-    def all_exist(self) -> bool:
+    def exists(self) -> bool:
         """
         Checks if all contained materials exist at specified paths.
         """
@@ -51,7 +51,7 @@ class BundleMaterials(VerificationMaterials):
 
         return mats
 
-    def all_exist(self) -> bool:
+    def exists(self) -> bool:
         return self.bundle.exists()
 
 
@@ -71,7 +71,7 @@ class SignatureCertificateMaterials(VerificationMaterials):
 
         return mats
 
-    def all_exist(self) -> bool:
+    def exists(self) -> bool:
         return self.signature.exists() and self.certificate.exists()
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,12 +6,8 @@ from typing import Tuple
 
 import pytest  # type: ignore
 
-from .client import (
-    BundleMaterials,
-    SignatureCertificateMaterials,
-    SigstoreClient,
-    VerificationMaterials,
-)
+from .client import (BundleMaterials, SignatureCertificateMaterials,
+                     SigstoreClient, VerificationMaterials)
 
 
 def pytest_addoption(parser):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,8 +10,8 @@ from .client import (BundleMaterials, SignatureCertificateMaterials,
                      SigstoreClient, VerificationMaterials)
 
 _M = TypeVar("_M", bound=VerificationMaterials)
-MakeMaterialsByType = Callable[[str, _M], Tuple[Path, _M]]
-MakeMaterials = Callable[[str], Tuple[Path, VerificationMaterials]]
+_MakeMaterialsByType = Callable[[str, _M], Tuple[Path, _M]]
+_MakeMaterials = Callable[[str], Tuple[Path, VerificationMaterials]]
 
 
 def pytest_addoption(parser):
@@ -38,7 +38,7 @@ def client(pytestconfig):
 
 
 @pytest.fixture
-def make_materials_by_type() -> MakeMaterialsByType:
+def make_materials_by_type() -> _MakeMaterialsByType:
     """
     Returns a function that constructs the requested subclass of
     `VerificationMaterials` alongside an appropriate input path.
@@ -56,7 +56,7 @@ def make_materials_by_type() -> MakeMaterialsByType:
 
 
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
-def make_materials(request, make_materials_by_type) -> MakeMaterials:
+def make_materials(request, make_materials_by_type) -> _MakeMaterials:
     """
     Returns a function that constructs `VerificationMaterials` alongside an
     appropriate input path. The subclass of `VerificationMaterials` that is returned

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,8 +6,12 @@ from typing import Tuple
 
 import pytest  # type: ignore
 
-from .client import (BundleMaterials, SignatureCertificateMaterials,
-                     SigstoreClient, VerificationMaterials)
+from .client import (
+    BundleMaterials,
+    SignatureCertificateMaterials,
+    SigstoreClient,
+    VerificationMaterials,
+)
 
 
 def pytest_addoption(parser):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -38,22 +38,22 @@ def client(pytestconfig):
 
 
 @pytest.fixture
-def construct_materials_for_cls():
-    def _materials(
-        input_name: str, mats_cls: VerificationMaterials
+def make_materials_by_type():
+    def _make_materials_by_type(
+        input_name: str, cls: VerificationMaterials
     ) -> Tuple[Path, VerificationMaterials]:
         input_path = Path(input_name)
-        output = mats_cls.from_input(input_path)
+        output = cls.from_input(input_path)
 
         return (input_path, output)
 
-    return _materials
+    return _make_materials_by_type
 
 
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
-def construct_materials(request, construct_materials_for_cls):
+def make_materials(request, make_materials_by_type):
     def _curry(input_name: str):
-        return construct_materials_for_cls(input_name, request.param)
+        return make_materials_by_type(input_name, request.param)
 
     return _curry
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,7 +48,7 @@ def construct_materials_for_cls():
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
 def construct_materials(request, construct_materials_for_cls):
     def _curry(input_name: str):
-        construct_materials_for_cls(input_name, request.param)
+        return construct_materials_for_cls(input_name, request.param)
 
     return _curry
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,12 +2,16 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Tuple
+from typing import Callable, Tuple, TypeVar
 
 import pytest  # type: ignore
 
 from .client import (BundleMaterials, SignatureCertificateMaterials,
                      SigstoreClient, VerificationMaterials)
+
+_M = TypeVar("_M", bound=VerificationMaterials)
+MakeMaterialsByType = Callable[[str, _M], Tuple[Path, _M]]
+MakeMaterials = Callable[[str], Tuple[Path, VerificationMaterials]]
 
 
 def pytest_addoption(parser):
@@ -34,7 +38,7 @@ def client(pytestconfig):
 
 
 @pytest.fixture
-def make_materials_by_type():
+def make_materials_by_type() -> MakeMaterialsByType:
     def _make_materials_by_type(
         input_name: str, cls: VerificationMaterials
     ) -> Tuple[Path, VerificationMaterials]:
@@ -47,7 +51,7 @@ def make_materials_by_type():
 
 
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
-def make_materials(request, make_materials_by_type):
+def make_materials(request, make_materials_by_type) -> MakeMaterials:
     def _make_materials(input_name: str):
         return make_materials_by_type(input_name, request.param)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,8 @@ def client(pytestconfig):
     Parametrize each test with the client under test.
     """
     entrypoint = pytestconfig.getoption("--entrypoint")
-    return SigstoreClient(entrypoint)
+    identity_token = pytestconfig.getoption("--identity-token")
+    return SigstoreClient(entrypoint, identity_token)
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,6 +39,11 @@ def client(pytestconfig):
 
 @pytest.fixture
 def make_materials_by_type() -> MakeMaterialsByType:
+    """
+    Returns a function that constructs the requested subclass of
+    `VerificationMaterials` alongside an appropriate input path.
+    """
+
     def _make_materials_by_type(
         input_name: str, cls: VerificationMaterials
     ) -> Tuple[Path, VerificationMaterials]:
@@ -52,6 +57,15 @@ def make_materials_by_type() -> MakeMaterialsByType:
 
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
 def make_materials(request, make_materials_by_type) -> MakeMaterials:
+    """
+    Returns a function that constructs `VerificationMaterials` alongside an
+    appropriate input path. The subclass of `VerificationMaterials` that is returned
+    is parameterized across `BundleMaterials` and `SignatureCertificateMaterials`.
+
+    See `make_materials_by_type` for a fixture that uses a specific subclass of
+    `VerificationMaterials`.
+    """
+
     def _make_materials(input_name: str):
         return make_materials_by_type(input_name, request.param)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,10 +48,10 @@ def make_materials_by_type():
 
 @pytest.fixture(params=[BundleMaterials, SignatureCertificateMaterials])
 def make_materials(request, make_materials_by_type):
-    def _curry(input_name: str):
+    def _make_materials(input_name: str):
         return make_materials_by_type(input_name, request.param)
 
-    return _curry
+    return _make_materials
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_certificate_verify.py
+++ b/test/test_certificate_verify.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from .client import SigstoreClient
+from .client import SignatureCertificateMaterials, SigstoreClient
 
 
 def test_verify_invalid_certificate_chain(client: SigstoreClient) -> None:
@@ -18,6 +18,10 @@ def test_verify_invalid_certificate_chain(client: SigstoreClient) -> None:
     artifact_path = Path("a.txt")
     signature_path = Path("a.txt.invalid.sig")
     certificate_path = Path("a.txt.invalid.crt")
+    materials = SignatureCertificateMaterials()
+
+    materials.certificate = certificate_path
+    materials.signature = signature_path
 
     with pytest.raises(subprocess.CalledProcessError):
-        client.verify(artifact_path, signature_path, certificate_path)
+        client.verify(materials, artifact_path)

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -6,12 +6,12 @@ import pytest  # type: ignore
 from .client import SignatureCertificateMaterials, SigstoreClient
 
 
-def test_verify_empty(client: SigstoreClient, construct_materials) -> None:
+def test_verify_empty(client: SigstoreClient, make_materials) -> None:
     """
     Tests that verification fails with empty artifacts, certificates and
     signatures.
     """
-    artifact_path, materials = construct_materials("a.txt")
+    artifact_path, materials = make_materials("a.txt")
 
     assert artifact_path.exists()
     assert not materials.exists()
@@ -32,12 +32,12 @@ def test_verify_empty(client: SigstoreClient, construct_materials) -> None:
     client.verify(materials, artifact_path)
 
 
-def test_verify_mismatch(client: SigstoreClient, construct_materials) -> None:
+def test_verify_mismatch(client: SigstoreClient, make_materials) -> None:
     """
     Tests that verification fails with mismatching artifacts, certificates and
     signatures.
     """
-    a_artifact_path, a_materials = construct_materials("a.txt")
+    a_artifact_path, a_materials = make_materials("a.txt")
 
     assert a_artifact_path.exists()
     assert not a_materials.exists()
@@ -47,7 +47,7 @@ def test_verify_mismatch(client: SigstoreClient, construct_materials) -> None:
     assert a_materials.exists()
 
     # Sign b.txt.
-    b_artifact_path, b_materials = construct_materials("b.txt")
+    b_artifact_path, b_materials = make_materials("b.txt")
 
     client.sign(b_materials, b_artifact_path)
     assert b_materials.exists()
@@ -60,15 +60,15 @@ def test_verify_mismatch(client: SigstoreClient, construct_materials) -> None:
     client.verify(a_materials, a_artifact_path)
 
 
-def test_verify_sigcrt(client: SigstoreClient, construct_materials_for_cls) -> None:
+def test_verify_sigcrt(client: SigstoreClient, make_materials_by_type) -> None:
     """
     Test cases for the signature+certificate flow: empty sigs/crts and
     mismatched sigs/crts.
     """
-    a_artifact_path, a_materials = construct_materials_for_cls(
+    a_artifact_path, a_materials = make_materials_by_type(
         "a.txt", SignatureCertificateMaterials
     )
-    b_artifact_path, b_materials = construct_materials_for_cls(
+    b_artifact_path, b_materials = make_materials_by_type(
         "b.txt", SignatureCertificateMaterials
     )
 

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -1,12 +1,13 @@
 import subprocess
 from pathlib import Path
+from test.conftest import MakeMaterials, MakeMaterialsByType
 
 import pytest  # type: ignore
 
 from .client import SignatureCertificateMaterials, SigstoreClient
 
 
-def test_verify_empty(client: SigstoreClient, make_materials) -> None:
+def test_verify_empty(client: SigstoreClient, make_materials: MakeMaterials) -> None:
     """
     Tests that verification fails with empty artifacts, certificates and
     signatures.
@@ -32,7 +33,7 @@ def test_verify_empty(client: SigstoreClient, make_materials) -> None:
     client.verify(materials, artifact_path)
 
 
-def test_verify_mismatch(client: SigstoreClient, make_materials) -> None:
+def test_verify_mismatch(client: SigstoreClient, make_materials: MakeMaterials) -> None:
     """
     Tests that verification fails with mismatching artifacts, certificates and
     signatures.
@@ -60,7 +61,9 @@ def test_verify_mismatch(client: SigstoreClient, make_materials) -> None:
     client.verify(a_materials, a_artifact_path)
 
 
-def test_verify_sigcrt(client: SigstoreClient, make_materials_by_type) -> None:
+def test_verify_sigcrt(
+    client: SigstoreClient, make_materials_by_type: MakeMaterialsByType
+) -> None:
     """
     Test cases for the signature+certificate flow: empty sigs/crts and
     mismatched sigs/crts.

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -60,9 +60,7 @@ def test_verify_mismatch(client: SigstoreClient, construct_materials) -> None:
     client.verify(a_materials, a_artifact_path)
 
 
-def test_verify_sigcrt(
-    client: SigstoreClient, construct_materials_for_cls
-) -> None:
+def test_verify_sigcrt(client: SigstoreClient, construct_materials_for_cls) -> None:
     """
     Test cases for the signature+certificate flow: empty sigs/crts and
     mismatched sigs/crts.
@@ -88,7 +86,7 @@ def test_verify_sigcrt(
         blank_sig.signature = blank_path
         blank_sig.certificate = a_materials.certificate
 
-        client.verify(blank_sig, a_materials)
+        client.verify(blank_sig, a_artifact_path)
 
     # Verify with an empty certificate.
     with pytest.raises(subprocess.CalledProcessError):
@@ -96,8 +94,7 @@ def test_verify_sigcrt(
         blank_crt.signature = a_materials.signature
         blank_crt.certificate = blank_path
 
-        client.verify(blank_crt, a_materials)
-
+        client.verify(blank_crt, a_artifact_path)
 
     # Verify with a mismatching certificate.
     with pytest.raises(subprocess.CalledProcessError):

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -30,11 +30,19 @@ def test_verify_empty(client: SigstoreClient, construct_materials) -> None:
 
     # Verify with an empty signature.
     with pytest.raises(subprocess.CalledProcessError):
-        client.verify(materials, artifact_path)
+        blank_sig = SignatureCertificateMaterials()
+        blank_sig.signature = blank_path
+        blank_sig.certificate = materials.certificate
+
+        client.verify(blank_sig, artifact_path)
 
     # Verify with an empty certificate.
     with pytest.raises(subprocess.CalledProcessError):
-        client.verify(materials, artifact_path)
+        blank_crt = SignatureCertificateMaterials()
+        blank_crt.signature = materials.signature
+        blank_crt.certificate = blank_path
+
+        client.verify(blank_crt, artifact_path)
 
     # Verify with correct inputs.
     client.verify(materials, artifact_path)
@@ -88,6 +96,10 @@ def test_verify_mismatch_sigcrt(
 
     materials_sig_mismatch.certificate = a_materials.certificate
     materials_sig_mismatch.signature = b_materials.signature
+
+    # Sign a.txt, b.txt.
+    client.sign(a_materials, a_artifact_path)
+    client.sign(b_materials, b_artifact_path)
 
     # Verify with a mismatching certificate.
     with pytest.raises(subprocess.CalledProcessError):

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -1,13 +1,13 @@
 import subprocess
 from pathlib import Path
-from test.conftest import MakeMaterials, MakeMaterialsByType
+from test.conftest import _MakeMaterials, _MakeMaterialsByType
 
 import pytest  # type: ignore
 
 from .client import SignatureCertificateMaterials, SigstoreClient
 
 
-def test_verify_empty(client: SigstoreClient, make_materials: MakeMaterials) -> None:
+def test_verify_empty(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
     """
     Tests that verification fails with empty artifacts, certificates and
     signatures.
@@ -33,7 +33,9 @@ def test_verify_empty(client: SigstoreClient, make_materials: MakeMaterials) -> 
     client.verify(materials, artifact_path)
 
 
-def test_verify_mismatch(client: SigstoreClient, make_materials: MakeMaterials) -> None:
+def test_verify_mismatch(
+    client: SigstoreClient, make_materials: _MakeMaterials
+) -> None:
     """
     Tests that verification fails with mismatching artifacts, certificates and
     signatures.
@@ -62,7 +64,7 @@ def test_verify_mismatch(client: SigstoreClient, make_materials: MakeMaterials) 
 
 
 def test_verify_sigcrt(
-    client: SigstoreClient, make_materials_by_type: MakeMaterialsByType
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
 ) -> None:
     """
     Test cases for the signature+certificate flow: empty sigs/crts and

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -2,8 +2,12 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from .client import (BundleMaterials, SignatureCertificateMaterials,
-                     SigstoreClient, VerificationMaterials)
+from .client import (
+    BundleMaterials,
+    SignatureCertificateMaterials,
+    SigstoreClient,
+    VerificationMaterials,
+)
 
 _input_path = Path("a.txt")
 _materials = [

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,7 +1,9 @@
+from test.conftest import MakeMaterials
+
 from .client import SigstoreClient
 
 
-def test_simple(client: SigstoreClient, make_materials) -> None:
+def test_simple(client: SigstoreClient, make_materials: MakeMaterials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore
     client.

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -12,7 +12,7 @@ _materials = [
 ]
 
 
-@pytest.parametrize("materials", _materials)
+@pytest.mark.parametrize("materials", _materials)
 def test_simple(client: SigstoreClient, materials: VerificationMaterials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,26 +1,28 @@
 from pathlib import Path
 
-from .client import SigstoreClient
+import pytest  # type: ignore
+
+from .client import (BundleMaterials, SignatureCertificateMaterials,
+                     SigstoreClient, VerificationMaterials)
+
+_input_path = Path("a.txt")
+_materials = [
+    BundleMaterials.from_input(_input_path),
+    SignatureCertificateMaterials.from_input(_input_path),
+]
 
 
-def test_simple(client: SigstoreClient) -> None:
+@pytest.parametrize("materials", _materials)
+def test_simple(client: SigstoreClient, materials: VerificationMaterials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore
     client.
     """
-    artifact_path = Path("a.txt")
-    signature_path = Path("a.txt.sig")
-    certificate_path = Path("a.txt.crt")
-
-    assert artifact_path.exists()
-    assert not signature_path.exists()
-    assert not certificate_path.exists()
+    assert not materials.all_exist()
 
     # Sign the artifact.
-    client.sign(artifact_path, signature_path, certificate_path)
-
-    assert signature_path.exists()
-    assert certificate_path.exists()
+    client.sign(materials, _input_path)
+    assert materials.all_exist()
 
     # Verify the artifact signature.
-    client.verify(artifact_path, signature_path, certificate_path)
+    client.verify(materials, _input_path)

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -18,11 +18,11 @@ def test_simple(client: SigstoreClient, materials: VerificationMaterials) -> Non
     A simple test that signs and verifies an artifact for a given Sigstore
     client.
     """
-    assert not materials.all_exist()
+    assert not materials.exists()
 
     # Sign the artifact.
     client.sign(materials, _input_path)
-    assert materials.all_exist()
+    assert materials.exists()
 
     # Verify the artifact signature.
     client.verify(materials, _input_path)

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,9 +1,9 @@
-from test.conftest import MakeMaterials
+from test.conftest import _MakeMaterials
 
 from .client import SigstoreClient
 
 
-def test_simple(client: SigstoreClient, make_materials: MakeMaterials) -> None:
+def test_simple(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore
     client.

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,10 +1,4 @@
-from pathlib import Path
-
-import pytest  # type: ignore
-
-from .client import (
-    SigstoreClient,
-)
+from .client import SigstoreClient
 
 
 def test_simple(client: SigstoreClient, make_materials) -> None:

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -3,30 +3,22 @@ from pathlib import Path
 import pytest  # type: ignore
 
 from .client import (
-    BundleMaterials,
-    SignatureCertificateMaterials,
     SigstoreClient,
-    VerificationMaterials,
 )
 
-_input_path = Path("a.txt")
-_materials = [
-    BundleMaterials.from_input(_input_path),
-    SignatureCertificateMaterials.from_input(_input_path),
-]
 
-
-@pytest.mark.parametrize("materials", _materials)
-def test_simple(client: SigstoreClient, materials: VerificationMaterials) -> None:
+def test_simple(client: SigstoreClient, make_materials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore
     client.
     """
+
+    input_path, materials = make_materials("a.txt")
     assert not materials.exists()
 
     # Sign the artifact.
-    client.sign(materials, _input_path)
+    client.sign(materials, input_path)
     assert materials.exists()
 
     # Verify the artifact signature.
-    client.verify(materials, _input_path)
+    client.verify(materials, input_path)


### PR DESCRIPTION
Adapts existing tests to cover the bundle flow (empty materials, mismatched materials, ...) To this effect, extends `SigstoreClient` to support the `*-bundle` subcommands.

Depends on #51.
Resolves #65.