### PR TITLE
conftest: Add `--identity-token` option back

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
 
 jobs:
   selftest:
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,12 +16,19 @@ _MakeMaterials = Callable[[str], Tuple[Path, VerificationMaterials]]
 
 def pytest_addoption(parser):
     """
-    Add the `--entrypoint` flag to the `pytest` CLI.
+    Add the `--entrypoint` and `--identity-token` flags to the `pytest` CLI.
     """
     parser.addoption(
         "--entrypoint",
         action="store",
         help="the command to invoke the Sigstore client under test",
+        required=True,
+        type=str,
+    )
+    parser.addoption(
+        "--identity-token",
+        action="store",
+        help="the OIDC token to supply to the Sigstore client under test",
         required=True,
         type=str,
     )


### PR DESCRIPTION
I see we have this fixed in https://github.com/sigstore/sigstore-conformance/pull/78 but we need to get this in now as it's disrupting other PRs from Dependabot.

I've also switched away from `pull_request_target` since we're no longer using ambient credentials.