### PR TITLE
action: invoke pytest through python

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,4 +26,3 @@ jobs:
         id: sigstore-conformance
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
-          internal-be-careful-debug: "true"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,3 +26,4 @@ jobs:
         id: sigstore-conformance
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
+          internal-be-careful-debug: "true"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: install sigstore-python
         # TODO: Remove this version pin once the 2.x series is released.
-        run: pip install "git+https://github.com/sigstore/sigstore-python.git@ww/bump-protobuf-specs"
+        run: pip install "sigstore==2.0.0rc2"
 
       - name: conformance test sigstore-python
         uses: ./

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: install sigstore-python
         # TODO: Remove this version pin once the 2.x series is released.
-        run: pip install sigstore==2.0.0rc1
+        run: pip install "git+https://github.com/sigstore/sigstore-python.git@ww/bump-protobuf-specs"
 
       - name: conformance test sigstore-python
         uses: ./

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: "pip"
 
       - name: install sigstore-python
         # TODO: Remove this version pin once the 2.x series is released.

--- a/action.py
+++ b/action.py
@@ -21,7 +21,9 @@ _TEMPLATES = _HERE / "templates"
 
 _SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY")).open("a")  # type: ignore
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_CONFORMANCE_SUMMARY", "true") == "true"
-_DEBUG = False
+_DEBUG = (
+    os.getenv("GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
+)
 _ACTION_PATH = Path(os.getenv("GITHUB_ACTION_PATH"))  # type: ignore
 _OIDC_BEACON_API_URL = (
     "https://api.github.com/repos/sigstore-conformance/extremely-dangerous-public-oidc-beacon/"

--- a/action.py
+++ b/action.py
@@ -21,9 +21,7 @@ _TEMPLATES = _HERE / "templates"
 
 _SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY")).open("a")  # type: ignore
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_CONFORMANCE_SUMMARY", "true") == "true"
-_DEBUG = (
-    os.getenv("GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
-)
+_DEBUG = False
 _ACTION_PATH = Path(os.getenv("GITHUB_ACTION_PATH"))  # type: ignore
 _OIDC_BEACON_API_URL = (
     "https://api.github.com/repos/sigstore-conformance/extremely-dangerous-public-oidc-beacon/"

--- a/action.py
+++ b/action.py
@@ -152,7 +152,7 @@ def _fatal_help(msg):
 sigstore_conformance_args = []
 
 if _DEBUG:
-    sigstore_conformance_args.extend(["-s", "-vv", "--showlocals"])
+    sigstore_conformance_args.extend(["-s", "-vv"])
 
 entrypoint = os.getenv("GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT")
 if entrypoint:
@@ -173,21 +173,5 @@ if status == 0:
 else:
     _summary("❌ sigstore-conformance found one or more test failures")
 
-_summary(
-    """
-<details>
-<summary>
-    Raw `sigstore-conformance` output
-</summary>
-
-```
-    """
-)
-_summary(
-    """
-```
-</details>
-    """
-)
 
 sys.exit(status)

--- a/action.py
+++ b/action.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional
 from zipfile import ZipFile
 
+import pytest
 import requests
 
 _HERE = Path(__file__).parent.resolve()
@@ -139,8 +140,8 @@ def _log(msg):
     print(msg, file=sys.stderr)
 
 
-def _sigstore_conformance(*args):
-    return ["pytest", _ACTION_PATH / "test", *args]
+def _sigstore_conformance(*args) -> int:
+    return pytest.main([str(_ACTION_PATH / "test"), *args])
 
 
 def _fatal_help(msg):
@@ -165,15 +166,9 @@ sigstore_conformance_args.extend(["--identity-token", oidc_token])
 
 _debug(f"running: sigstore-conformance {[str(a) for a in sigstore_conformance_args]}")
 
-status = subprocess.run(
-    _sigstore_conformance(*sigstore_conformance_args),
-    text=True,
-    capture_output=True,
-)
+status = _sigstore_conformance(*sigstore_conformance_args)
 
-_debug(status.stdout)
-
-if status.returncode == 0:
+if status == 0:
     _summary("🎉 sigstore-conformance exited successfully")
 else:
     _summary("❌ sigstore-conformance found one or more test failures")
@@ -188,7 +183,6 @@ _summary(
 ```
     """
 )
-_log(status.stdout)
 _summary(
     """
 ```
@@ -196,4 +190,4 @@ _summary(
     """
 )
 
-sys.exit(status.returncode)
+sys.exit(status)

--- a/action.py
+++ b/action.py
@@ -5,8 +5,6 @@
 # all state is passed in as environment variables
 
 import os
-import string
-import subprocess
 import sys
 import time
 from datetime import datetime, timedelta
@@ -121,11 +119,6 @@ def _get_oidc_token() -> str:
         return artifact_file.read().decode().rstrip()
 
 
-def _template(name):
-    path = _TEMPLATES / f"{name}.md"
-    return string.Template(path.read_text())
-
-
 def _summary(msg):
     if _RENDER_SUMMARY:
         print(msg, file=_SUMMARY)
@@ -152,7 +145,7 @@ def _fatal_help(msg):
 sigstore_conformance_args = []
 
 if _DEBUG:
-    sigstore_conformance_args.extend(["-s", "-vv"])
+    sigstore_conformance_args.extend(["-s", "-vv", "--showlocals"])
 
 entrypoint = os.getenv("GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT")
 if entrypoint:

--- a/action.py
+++ b/action.py
@@ -16,9 +16,6 @@ from zipfile import ZipFile
 import pytest
 import requests
 
-_HERE = Path(__file__).parent.resolve()
-_TEMPLATES = _HERE / "templates"
-
 _SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY")).open("a")  # type: ignore
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_CONFORMANCE_SUMMARY", "true") == "true"
 _DEBUG = (

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   internal-be-careful-debug:
     description: "run with debug logs (default false)"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "composite"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest==7.1.3
 requests==2.31.0
 cryptography>=39
-sigstore-protobuf-specs~=0.1.0
+sigstore-protobuf-specs~=0.2.0

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -4,6 +4,7 @@
 A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `sigstore-python`.
 """
 
+import os
 import subprocess
 import sys
 
@@ -40,4 +41,4 @@ elif subcommand == "verify":
 else:
     raise ValueError(f"unsupported subcommand: {subcommand}")
 
-subprocess.run(fixed_args, text=True, check=True)
+os.execvp("sigstore", fixed_args)

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -5,7 +5,6 @@ A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `s
 """
 
 import os
-import subprocess
 import sys
 
 SUBCMD_REPLACEMENTS = {

--- a/test/client.py
+++ b/test/client.py
@@ -29,6 +29,10 @@ Exit code: {exitcode}
 """
 
 
+class ClientFail(Exception):
+    pass
+
+
 class VerificationMaterials:
     """
     A wrapper around verification materials. Materials can be either bundles
@@ -124,12 +128,13 @@ class SigstoreClient:
                 check=True,
             )
         except subprocess.CalledProcessError as cpe:
-            assert False, _CLIENT_ERROR_MSG.format(
+            msg = _CLIENT_ERROR_MSG.format(
                 exitcode=cpe.returncode,
                 args=cpe.args,
                 stdout=cpe.stdout,
                 stderr=cpe.stderr,
             )
+            raise ClientFail(msg)
 
     @singledispatchmethod
     def sign(self, materials: VerificationMaterials, artifact: os.PathLike) -> None:

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -1,6 +1,5 @@
 from pathlib import Path
-from subprocess import CalledProcessError
-from test.client import BundleMaterials, SigstoreClient
+from test.client import BundleMaterials, ClientFail, SigstoreClient
 from test.conftest import _MakeMaterialsByType
 
 import pytest  # type: ignore
@@ -20,7 +19,7 @@ def test_verify_rejects_root(
         "has_root_in_chain.txt", BundleMaterials
     )
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, input_path)
 
 
@@ -67,7 +66,7 @@ def test_verify_rejects_staging_cert(
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.staging.sigstore")
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, input_path)
 
 
@@ -83,7 +82,7 @@ def test_verify_rejects_invalid_set(
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.invalid_set.sigstore")
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, input_path)
 
 
@@ -98,7 +97,7 @@ def test_verify_rejects_invalid_signature(
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.invalid_signature.sigstore")
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, input_path)
 
 
@@ -113,5 +112,5 @@ def test_verify_rejects_invalid_digest(
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.invalid_digest.sigstore")
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, input_path)

--- a/test/test_certificate_verify.py
+++ b/test/test_certificate_verify.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from .client import SignatureCertificateMaterials, SigstoreClient
+from .client import ClientFail, SignatureCertificateMaterials, SigstoreClient
 
 
 def test_verify_invalid_certificate_chain(client: SigstoreClient) -> None:
@@ -23,5 +23,5 @@ def test_verify_invalid_certificate_chain(client: SigstoreClient) -> None:
     materials.certificate = certificate_path
     materials.signature = signature_path
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, artifact_path)

--- a/test/test_certificate_verify.py
+++ b/test/test_certificate_verify.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 
 import pytest  # type: ignore

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -4,7 +4,7 @@ from test.conftest import _MakeMaterials, _MakeMaterialsByType
 
 import pytest  # type: ignore
 
-from .client import SignatureCertificateMaterials, SigstoreClient
+from .client import ClientFail, SignatureCertificateMaterials, SigstoreClient
 
 
 def test_verify_empty(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
@@ -26,7 +26,7 @@ def test_verify_empty(client: SigstoreClient, make_materials: _MakeMaterials) ->
     blank_path.touch()
 
     # Verify with an empty artifact.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(materials, blank_path)
 
     # Verify with correct inputs.
@@ -56,7 +56,7 @@ def test_verify_mismatch(
     assert b_materials.exists()
 
     # Verify with a mismatching artifact.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         client.verify(a_materials, b_artifact_path)
 
     # Verify with correct inputs.
@@ -86,7 +86,7 @@ def test_verify_sigcrt(
     blank_path.touch()
 
     # Verify with an empty signature.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         blank_sig = SignatureCertificateMaterials()
         blank_sig.signature = blank_path
         blank_sig.certificate = a_materials.certificate
@@ -94,7 +94,7 @@ def test_verify_sigcrt(
         client.verify(blank_sig, a_artifact_path)
 
     # Verify with an empty certificate.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         blank_crt = SignatureCertificateMaterials()
         blank_crt.signature = a_materials.signature
         blank_crt.certificate = blank_path
@@ -102,7 +102,7 @@ def test_verify_sigcrt(
         client.verify(blank_crt, a_artifact_path)
 
     # Verify with a mismatching certificate.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         crt_mismatch = SignatureCertificateMaterials()
         crt_mismatch.certificate = b_materials.certificate
         crt_mismatch.signature = a_materials.signature
@@ -110,7 +110,7 @@ def test_verify_sigcrt(
         client.verify(crt_mismatch, a_artifact_path)
 
     # Verify with a mismatching signature.
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(ClientFail):
         sig_mismatch = SignatureCertificateMaterials()
         sig_mismatch.certificate = a_materials.certificate
         sig_mismatch.signature = b_materials.signature

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 from test.conftest import _MakeMaterials, _MakeMaterialsByType
 


### PR DESCRIPTION
This shaves down a few of the layers of indirection in the conformance suite, which will (hopefully) make error messages easier to sift through in the future.

Closes #88.