### PR TITLE
Make it easier to run verification test locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ invoke the client.
 Running the conformance suite locally,
 
 ```sh
-(env) $ pytest --entrypoint=SIGSTORE_CLIENT --identity-token=$(gh auth token)
+(env) $ pytest test --entrypoint=SIGSTORE_CLIENT --identity-token=$(gh auth token)
+```
+
+Or if you are only checking verification use cases,
+
+```sh
+(env) $ pytest test --skip-signing --entrypoint=SIGSTORE_CLIENT
 ```
 
 Using the [`gh` CLI](https://cli.github.com/) and noting SIGSTORE_CLIENT is the absolute path to a client implementing the [CLI specification](https://github.com/sigstore/sigstore-conformance/blob/main/docs/cli_protocol.md).

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,6 +36,10 @@ class OidcTokenError(Exception):
     pass
 
 
+class ConfigError(Exception):
+    pass
+
+
 def pytest_addoption(parser) -> None:
     """
     Add the `--entrypoint`, `--github-token`, and `--skip-signing` flags to
@@ -67,7 +71,18 @@ def pytest_runtest_setup(item):
 
 
 def pytest_configure(config):
+    if not config.getoption("--github-token") and not config.getoption("--skip-signing"):
+        raise ConfigError("Please specify one of '--github-token' or '--skip-signing'")
+
     config.addinivalue_line("markers", "signing: mark test as requiring signing functionality")
+
+
+def pytest_internalerror(excrepr, excinfo):
+    if excinfo.type == ConfigError:
+        print(excinfo.value)
+        return True
+
+    return False
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,6 @@ def pytest_addoption(parser) -> None:
         "--github-token",
         action="store",
         help="the GitHub token to supply to the Sigstore client under test",
-        required=True,
         type=str,
     )
     parser.addoption(
@@ -73,6 +72,9 @@ def pytest_configure(config):
 
 @pytest.fixture
 def identity_token(pytestconfig) -> str:
+    if pytestconfig.getoption("--skip-signing"):
+        return ""
+
     gh_token = pytestconfig.getoption("--github-token")
     session = requests.Session()
     headers = {


### PR DESCRIPTION
For #99

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

If you're only testing verification use-cases locally, you don't need the OIDC JWT.

You can test this change with:

```sh
(env) $ pytest test --skip-signing --entrypoint=SIGSTORE_CLIENT
```


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Enabled easier local testing for verification with `pytest test --skip-signing --entrypoint=SIGSTORE_CLIENT`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A