### PR TITLE
Allow multiple artifacts to exist

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -137,18 +137,14 @@ def identity_token(pytestconfig) -> str:
     resp.raise_for_status()
 
     resp_json = resp.json()
-    artifacts = resp_json["artifacts"]
-    if len(artifacts) != 1:
-        raise OidcTokenError(
-            f"Found unexpected number of artifacts on OIDC beacon run: {artifacts}"
-        )
+    artifact_id = None
 
-    oidc_artifact = artifacts[0]
-    if oidc_artifact["name"] != "oidc-token":
-        raise OidcTokenError(
-            f"Found unexpected artifact on OIDC beacon run: {oidc_artifact['name']}"
-        )
-    artifact_id = oidc_artifact["id"]
+    for oidc_artifact in resp_json["artifacts"]:
+        if oidc_artifact["name"] == "oidc-token":
+            artifact_id = oidc_artifact["id"]
+
+    if not artifact_id:
+        raise OidcTokenError("Artifact 'oidc-token' could not be found")
 
     # Download the OIDC token artifact and unzip the archive.
     resp = session.get(


### PR DESCRIPTION

#### Summary

This relates to https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/issues/5

I'm planning to publish the (extremely-dangerous-public-oidc) token in GitHub Pages to make it easier to use. The only realistic way to do that is to use actions/upload-pages-artifact and then actions/deploy-pages -- the currently uploaded artifact is not usable for this.

This commit makes the script not fail if there are multiple artifacts, but still uses the same artifact as before. This makes it possible to start publishing a new 'github-pages' artifact without immediately breaking this script.

#### Release Note

NONE

#### Documentation

NONE