### PR TITLE
feat:checking that the client is allowed to run against staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Or if you are only checking verification use cases,
 (env) $ pytest test --skip-signing --entrypoint=SIGSTORE_CLIENT
 ```
 
+You can also run the tests against staging by adding `--staging` on the command,
+
+```sh
+(env) $ pytest test --staging --entrypoint=SIGSTORE_CLIENT
+```
+
 Using the [`gh` CLI](https://cli.github.com/) and noting SIGSTORE_CLIENT is the absolute path to a client implementing the [CLI specification](https://github.com/sigstore/sigstore-conformance/blob/main/docs/cli_protocol.md).
 
 ## Licensing

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -28,7 +28,7 @@ To simplify argument parsing, all arguments are required, except `--staging`, an
 supplied by the conformance suite in the order that they are specified in the
 templates below.
 
-All commands below are allowed to run against staging, adding the `--staging` in the command, for example:
+All commands below are allowed to run against staging by appending the `--staging` in the command, for example:
 
 ```console
 ${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FILE --staging

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -24,9 +24,15 @@ client's native CLI accepts.
 This is the set of subcommands that the test CLI must support. Each subcommand
 has a provided syntax and list of descriptions for each argument.
 
-To simplify argument parsing, all arguments are required and will **always** be
+To simplify argument parsing, all arguments are required, except `--staging`, and will **always** be
 supplied by the conformance suite in the order that they are specified in the
 templates below.
+
+All commands below are allowed to run against staging, adding the `--staging` in the command, for example:
+
+```console
+${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FILE --staging
+```
 
 ### Sign
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,6 +63,11 @@ def pytest_addoption(parser) -> None:
         action="store_true",
         help="skip tests that require signing functionality",
     )
+    parser.addoption(
+        "--staging",
+        action="store_true",
+        help="run tests against staging",
+    )
 
 
 def pytest_runtest_setup(item):
@@ -162,7 +167,8 @@ def client(pytestconfig, identity_token):
     Parametrize each test with the client under test.
     """
     entrypoint = pytestconfig.getoption("--entrypoint")
-    return SigstoreClient(entrypoint, identity_token)
+    staging = pytestconfig.getoption("--staging")
+    return SigstoreClient(entrypoint, identity_token, staging)
 
 
 @pytest.fixture

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -19,7 +19,9 @@ def test_verify(client: SigstoreClient, make_materials_by_type: _MakeMaterialsBy
     client.verify(materials, input_path)
 
 
-def test_verify_dsse_bundle_with_trust_root(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_dsse_bundle_with_trust_root(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Test the happy path of verification for DSSE bundle w/ custom trust root
     """
@@ -170,7 +172,9 @@ def test_verify_rejects_different_materials(
         client.verify(materials, input_path)
 
 
-def test_verify_rejects_expired_certificate(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_rejects_expired_certificate(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Check that the client rejects a bundle if the certificate was issued
     outside the validity window of the trusted root
@@ -184,7 +188,9 @@ def test_verify_rejects_expired_certificate(client: SigstoreClient, make_materia
         client.verify(materials, input_path)
 
 
-def test_verify_rejects_missing_inclusion_proof(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_rejects_missing_inclusion_proof(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Check that the client rejects a v0.2 bundle if the TLog entry does NOT
     contain an inclusion proof
@@ -198,7 +204,9 @@ def test_verify_rejects_missing_inclusion_proof(client: SigstoreClient, make_mat
         client.verify(materials, input_path)
 
 
-def test_verify_rejects_bad_tlog_timestamp(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_rejects_bad_tlog_timestamp(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Check that the client rejects a bundle if the TLog entry contains a
     timestamp that falls outside the validity window of the signing
@@ -213,7 +221,9 @@ def test_verify_rejects_bad_tlog_timestamp(client: SigstoreClient, make_material
         client.verify(materials, input_path)
 
 
-def test_verify_rejects_bad_tlog_entry(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_rejects_bad_tlog_entry(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Check that the client rejects a bundle if the body of the TLog entry does
     not match the signed artifact.
@@ -226,7 +236,10 @@ def test_verify_rejects_bad_tlog_entry(client: SigstoreClient, make_materials_by
     with client.raises():
         client.verify(materials, input_path)
 
-def test_verify_rejects_bad_tsa_timestamp(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+
+def test_verify_rejects_bad_tsa_timestamp(
+    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+) -> None:
     """
     Check that the client rejects a bundle if the TSA timestamp falls outside
     the validity window of the signing certificate.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #121 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
One conformance requirement for the clients is that they should be able to run the commands against `staging`.  After this PR, the clients should be able to receive the `--staging` token in the command line and point to staging resources.

#### Release Note

Updated client run function to receive `staging` argument.
Updated run subprocess call to pass `--staging` flag to clients cli when required.
Modified CLI parser to receive --staging flag
Update CLI and conformance READMEs adding staging features
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
