### PR TITLE
Add staging to selftest

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,4 +25,5 @@ jobs:
         id: sigstore-conformance
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
+          enable-staging: true
           xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root"

--- a/README.md
+++ b/README.md
@@ -34,28 +34,34 @@ Some general testing principles for this suite are:
 
 ## Usage
 
-Simply add `sigstore/sigstore-conformance` to one of your workflows:
+1. Include an executable in your project that implements the
+client-under-test [CLI protocol](docs/cli_protocol.md).
+2. Use the `sigstore/sigstore-conformance` action in your test workflow:
+    ```yaml
+    jobs:
+      conformance:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          # insert your client installation steps here
+          - uses: sigstore/sigstore-conformance@v0.0.10
+            with:
+              entrypoint: my-conformance-client
+    ```
 
-```yaml
-jobs:
-  conformance:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: install
-        run: python -m pip install .
-      - uses: sigstore/sigstore-conformance@v0.0.10
-        with:
-          entrypoint: sigstore
-```
+See [sigstore-python conformance test](https://github.com/sigstore/sigstore-python/blob/main/.github/workflows/conformance.yml)
+for a complete example.
 
-The only required configuration is the `entrypoint` parameter which provides a
-command to invoke the client. `sigstore-conformance` expects that the client
-exposes a CLI that conforms to the protocol outlined [here](docs/cli_protocol.md).
+### `sigstore/sigstore-conformance` action inputs
 
-In the example above, the workflow is installing [sigstore-python](https://github.com/sigstore/sigstore-python)
-and providing `sigstore` as the `entrypoint` since this is the command used to
-invoke the client.
+The important action inputs are
+* `entrypoint`: required string. A command that implements the client-under-test
+  [CLI protocol](docs/cli_protocol.md)
+* `enable-staging`: optional boolean. When true, the test suite will run tests against
+  staging infrastructure in addition to running them against production infrastructure
+* `xfail`: optional string. Whitespace separated test names that are expected to fail.
+
+See [action.yml](action.yml) for full list of inputs.
 
 ## Development
 

--- a/action.py
+++ b/action.py
@@ -48,15 +48,11 @@ def _sigstore_conformance(staging: bool) -> int:
     if gh_token:
         args.extend(["--github-token", gh_token])
 
+    infra = "staging" if staging else "production"
+    print(f"running sigstore-conformance against Sigstore {infra} infrastructure")
     _debug(f"running: sigstore-conformance {[str(a) for a in args]}")
-    status = pytest.main([str(_ACTION_PATH / "test"), *args])
 
-    if status == 0:
-        _summary("🎉 sigstore-conformance exited successfully")
-    else:
-        _summary("❌ sigstore-conformance found one or more test failures")
-
-    return status
+    return pytest.main([str(_ACTION_PATH / "test"), *args])
 
 
 # Run against production, then optionally against staging
@@ -64,5 +60,9 @@ status = _sigstore_conformance(staging=False)
 if _ENABLE_STAGING:
     status += _sigstore_conformance(staging=True)
 
+if status == 0:
+    _summary("🎉 sigstore-conformance exited successfully")
+else:
+    _summary("❌ sigstore-conformance found one or more test failures")
 
 sys.exit(status)

--- a/action.py
+++ b/action.py
@@ -14,6 +14,7 @@ _SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY")).open("a")  # type: ignore
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_CONFORMANCE_SUMMARY", "true") == "true"
 _DEBUG = os.getenv("GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
 _ACTION_PATH = Path(os.getenv("GITHUB_ACTION_PATH"))  # type: ignore
+_ENABLE_STAGING = os.getenv("GHA_SIGSTORE_CONFORMANCE_ENABLE_STAGING", "false").lower() == "true"
 
 
 def _summary(msg):
@@ -26,35 +27,42 @@ def _debug(msg):
         print(f"\033[93mDEBUG: {msg}\033[0m", file=sys.stderr)
 
 
-def _sigstore_conformance(*args) -> int:
-    return pytest.main([str(_ACTION_PATH / "test"), *args])
+def _sigstore_conformance(staging: bool) -> int:
+    args = []
+
+    if _DEBUG:
+        args.extend(["-s", "-vv", "--showlocals"])
+
+    entrypoint = os.getenv("GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT")
+    if entrypoint:
+        args.extend(["--entrypoint", entrypoint])
+
+    if staging:
+        args.append("--staging")
+
+    skip_signing = os.getenv("GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING", "false").lower() == "true"
+    if skip_signing:
+        args.extend(["--skip-signing"])
+
+    gh_token = os.getenv("GHA_SIGSTORE_GITHUB_TOKEN")
+    if gh_token:
+        args.extend(["--github-token", gh_token])
+
+    _debug(f"running: sigstore-conformance {[str(a) for a in args]}")
+    status = pytest.main([str(_ACTION_PATH / "test"), *args])
+
+    if status == 0:
+        _summary("🎉 sigstore-conformance exited successfully")
+    else:
+        _summary("❌ sigstore-conformance found one or more test failures")
+
+    return status
 
 
-sigstore_conformance_args = []
-
-if _DEBUG:
-    sigstore_conformance_args.extend(["-s", "-vv", "--showlocals"])
-
-entrypoint = os.getenv("GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT")
-if entrypoint:
-    sigstore_conformance_args.extend(["--entrypoint", entrypoint])
-
-skip_signing = os.getenv("GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING", "false").lower() == "true"
-if skip_signing:
-    sigstore_conformance_args.extend(["--skip-signing"])
-
-gh_token = os.getenv("GHA_SIGSTORE_GITHUB_TOKEN")
-if gh_token:
-    sigstore_conformance_args.extend(["--github-token", gh_token])
-
-_debug(f"running: sigstore-conformance {[str(a) for a in sigstore_conformance_args]}")
-
-status = _sigstore_conformance(*sigstore_conformance_args)
-
-if status == 0:
-    _summary("🎉 sigstore-conformance exited successfully")
-else:
-    _summary("❌ sigstore-conformance found one or more test failures")
+# Run against production, then optionally against staging
+status = _sigstore_conformance(staging=False)
+if _ENABLE_STAGING:
+    status += _sigstore_conformance(staging=True)
 
 
 sys.exit(status)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "skip tests that involve signing (default false)"
     required: false
     default: "false"
+  enable-staging:
+    description: "Test against staging infrastructure as well as production (default false)"
+    required: false
+    default: "false"
   xfail:
     description: "one or more tests that are expected to fail, whitespace-separated"
     required: false
@@ -34,6 +38,7 @@ runs:
       run: |
         ${{ github.action_path }}/action.py
       env:
+        GHA_SIGSTORE_CONFORMANCE_ENABLE_STAGING: "${{ inputs.enable-staging }}"
         GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT: "${{ inputs.entrypoint }}"
         GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG: "${{ inputs.internal-be-careful-debug }}"
         GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING: "${{ inputs.skip-signing }}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,6 +73,8 @@ def pytest_addoption(parser) -> None:
 def pytest_runtest_setup(item):
     if "signing" in item.keywords and item.config.getoption("--skip-signing"):
         pytest.skip("skipping test that requires signing support due to `--skip-signing` flag")
+    if "staging" not in item.keywords and item.config.getoption("--staging"):
+        pytest.skip("skipping test that does not support staging yet due to `--staging` flag")
 
 
 def pytest_configure(config):
@@ -80,6 +82,7 @@ def pytest_configure(config):
         raise ConfigError("Please specify one of '--github-token' or '--skip-signing'")
 
     config.addinivalue_line("markers", "signing: mark test as requiring signing functionality")
+    config.addinivalue_line("markers", "staging: mark test as supporting testing against staging")
 
 
 def pytest_internalerror(excrepr, excinfo):

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -7,6 +7,7 @@ from .client import SignatureCertificateMaterials, SigstoreClient
 
 
 @pytest.mark.signing
+@pytest.mark.staging
 def test_verify_empty(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
     """
     Tests that verification fails with empty artifacts, certificates and
@@ -34,6 +35,7 @@ def test_verify_empty(client: SigstoreClient, make_materials: _MakeMaterials) ->
 
 
 @pytest.mark.signing
+@pytest.mark.staging
 def test_verify_mismatch(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
     """
     Tests that verification fails with mismatching artifacts, certificates and

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -6,6 +6,7 @@ from .client import SigstoreClient
 
 
 @pytest.mark.signing
+@pytest.mark.staging
 def test_simple(client: SigstoreClient, make_materials: _MakeMaterials) -> None:
     """
     A simple test that signs and verifies an artifact for a given Sigstore


### PR DESCRIPTION
This might be enough to close #121.

#### Summary

Do several small changes required to support staging tests in self-test
* the `enable-staging` action input defaults to false: we may want to reconsider before releasing -- maybe opt-out is better?
* only a few tests are marked as compatible with staging at this point: I may have missed some but since there are loads of false negatives in the remaining tests (tests that seemingly have the correct result but only because they fail for the wrong reasons on staging) I didn't want to extend without research

#### TODO?

* `--staging` flag is sort of  documented in cli_protocol.md but it could probably be improved 

Test run https://github.com/sigstore/sigstore-conformance/actions/runs/8017481217