### PR TITLE
Tweak staging invocation

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '10 10 * * *'
 
 jobs:
   selftest:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   selftest:
@@ -22,8 +23,13 @@ jobs:
 
       - name: conformance test sigstore-python
         uses: ./
-        id: sigstore-conformance
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
-          enable-staging: true
+          xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root"
+
+      - name: Staging conformance test sigstore-python
+        uses: ./
+        with:
+          entrypoint: ${{ github.workspace }}/sigstore-python-conformance
+          environment: staging
           xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root"

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ dev: env/pyvenv.cfg
 .PHONY: lint
 lint: env/pyvenv.cfg $(ALL_PY_SRCS)
 	./env/bin/python -m black $(ALL_PY_SRCS)
-	./env/bin/python -m ruff --fix $(ALL_PY_SRCS)
+	./env/bin/python -m ruff check --fix $(ALL_PY_SRCS)
 	./env/bin/python -m mypy action.py test/

--- a/README.md
+++ b/README.md
@@ -43,10 +43,19 @@ client-under-test [CLI protocol](docs/cli_protocol.md).
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
+
           # insert your client installation steps here
+
+          # Run tests against production Sigstore environment
           - uses: sigstore/sigstore-conformance@v0.0.10
             with:
               entrypoint: my-conformance-client
+
+          # Run tests against staging Sigstore environment
+          - uses: sigstore/sigstore-conformance@v0.0.10
+            with:
+              entrypoint: my-conformance-client
+              environment: staging
     ```
 
 See [sigstore-python conformance test](https://github.com/sigstore/sigstore-python/blob/main/.github/workflows/conformance.yml)
@@ -57,8 +66,8 @@ for a complete example.
 The important action inputs are
 * `entrypoint`: required string. A command that implements the client-under-test
   [CLI protocol](docs/cli_protocol.md)
-* `enable-staging`: optional boolean. When true, the test suite will run tests against
-  staging infrastructure in addition to running them against production infrastructure
+* `environment`: 'production' (default) or 'staging'. This selects the Sigstore environment to
+  run against
 * `xfail`: optional string. Whitespace separated test names that are expected to fail.
 
 See [action.yml](action.yml) for full list of inputs.
@@ -77,8 +86,7 @@ The test suite can be configured with
   [CLI specification](https://github.com/sigstore/sigstore-conformance/blob/main/docs/cli_protocol.md)
 * `--identity-token=$GITHUB_TOKEN` where GITHUB_TOKEN is a GitHub token with actions:read
   access for public repositories (--identity-token is only required for signing tests)
-* optional (and currently experimental) `--staging`: This instructs the test suite to run
-  against Sigstore staging infrastructure
+* optional `--staging`: This instructs the test suite to run against Sigstore staging infrastructure
 * The environment variable `GHA_SIGSTORE_CONFORMANCE_XFAIL` can be used to
   set expected results
 

--- a/action.py
+++ b/action.py
@@ -15,6 +15,7 @@ _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_CONFORMANCE_SUMMARY", "true") == "true
 _DEBUG = os.getenv("GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
 _ACTION_PATH = Path(os.getenv("GITHUB_ACTION_PATH"))  # type: ignore
 
+
 def _summary(msg):
     if _RENDER_SUMMARY:
         print(msg, file=_SUMMARY)

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: "skip tests that involve signing (default false)"
     required: false
     default: "false"
-  enable-staging:
-    description: "Test against staging infrastructure as well as production (default false)"
+  environment:
+    description: "'production' (default) or 'staging'"
     required: false
-    default: "false"
+    default: "production"
   xfail:
     description: "one or more tests that are expected to fail, whitespace-separated"
     required: false
@@ -38,7 +38,7 @@ runs:
       run: |
         ${{ github.action_path }}/action.py
       env:
-        GHA_SIGSTORE_CONFORMANCE_ENABLE_STAGING: "${{ inputs.enable-staging }}"
+        GHA_SIGSTORE_CONFORMANCE_ENVIRONMENT: "${{ inputs.environment }}"
         GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT: "${{ inputs.entrypoint }}"
         GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG: "${{ inputs.internal-be-careful-debug }}"
         GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING: "${{ inputs.skip-signing }}"

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -26,7 +26,6 @@ has a provided syntax and list of descriptions for each argument.
 
 To simplify argument parsing, arguments will **always** be supplied by the
 conformance suite in the order that they are specified in the templates below.
-Other arguments are always present but `--staging` is optional.
 
 ### Sign
 

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -24,26 +24,21 @@ client's native CLI accepts.
 This is the set of subcommands that the test CLI must support. Each subcommand
 has a provided syntax and list of descriptions for each argument.
 
-To simplify argument parsing, all arguments are required, except `--staging`, and will **always** be
-supplied by the conformance suite in the order that they are specified in the
-templates below.
-
-All commands below are allowed to run against staging by appending the `--staging` in the command, for example:
-
-```console
-${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FILE --staging
-```
+To simplify argument parsing, arguments will **always** be supplied by the
+conformance suite in the order that they are specified in the templates below.
+Other arguments are always present but `--staging` is optional.
 
 ### Sign
 
 #### Signature and certificate flow
 
 ```console
-${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FILE
+${ENTRYPOINT} sign [--staging] --identity-token TOKEN --signature FILE --certificate FILE FILE
 ```
 
 | Option | Description |
 | --- | --- |
+| `--staging`        | Presence indicates client should use Sigstore staging infrastructure |
 | `--identity-token` | The OIDC identity token to use |
 | `--signature FILE` | The path to write the signature to |
 | `--certificate FILE` | The path to write the signing certificate to |
@@ -52,11 +47,12 @@ ${ENTRYPOINT} sign --identity-token TOKEN --signature FILE --certificate FILE FI
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} sign-bundle --identity-token TOKEN --bundle FILE FILE
+${ENTRYPOINT} sign-bundle [--staging] --identity-token TOKEN --bundle FILE FILE
 ```
 
 | Option | Description |
 | --- | --- |
+| `--staging`        | Presence indicates client should use Sigstore staging infrastructure |
 | `--identity-token` | The OIDC identity token to use |
 | `--bundle FILE` | The path to write the bundle to |
 | `FILE` | The artifact to sign |
@@ -66,11 +62,12 @@ ${ENTRYPOINT} sign-bundle --identity-token TOKEN --bundle FILE FILE
 #### Signature and certificate flow
 
 ```console
-${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE
+${ENTRYPOINT} verify [--staging] --signature FILE --certificate FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE
 ```
 
 | Option | Description |
 | --- | --- |
+| `--staging`        | Presence indicates client should use Sigstore staging infrastructure |
 | `--signature FILE` | The path to the signature to verify |
 | `--certificate FILE` | The path to the signing certificate to verify |
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
@@ -81,11 +78,12 @@ ${ENTRYPOINT} verify --signature FILE --certificate FILE --certificate-identity 
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} verify-bundle --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE
+${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE
 ```
 
 | Option | Description |
 | --- | --- |
+| `--staging`        | Presence indicates client should use Sigstore staging infrastructure |
 | `--bundle FILE` | The path to the Sigstore bundle to verify |
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
-select = ["E", "F", "I", "W", "UP"]
+lint.select = ["E", "F", "I", "W", "UP"]

--- a/test/client.py
+++ b/test/client.py
@@ -128,8 +128,6 @@ class SigstoreClient:
         """
         self.completed_process = None
         full_command = [self.entrypoint, *args]
-        if self.staging:
-            full_command.append("--staging")
 
         try:
             self.completed_process = subprocess.run(
@@ -187,16 +185,20 @@ class SigstoreClient:
         This is an overload of `sign` for the signature/certificate flow and should not
         be called directly.
         """
-        args = [
-            "sign",
-            "--identity-token",
-            self.identity_token,
-            "--signature",
-            materials.signature,
-            "--certificate",
-            materials.certificate,
-            artifact,
-        ]
+        args: list[str | os.PathLike] = ["sign"]
+        if self.staging:
+            args.append("--staging")
+        args.extend(
+            [
+                "--identity-token",
+                self.identity_token,
+                "--signature",
+                materials.signature,
+                "--certificate",
+                materials.certificate,
+                artifact,
+            ]
+        )
 
         self.run(*args)
 
@@ -208,14 +210,18 @@ class SigstoreClient:
         This is an overload of `sign` for the bundle flow and should not be called directly.
         """
 
-        args = [
-            "sign-bundle",
-            "--identity-token",
-            self.identity_token,
-            "--bundle",
-            materials.bundle,
-            artifact,
-        ]
+        args: list[str | os.PathLike] = ["sign-bundle"]
+        if self.staging:
+            args.append("--staging")
+        args.extend(
+            [
+                "--identity-token",
+                self.identity_token,
+                "--bundle",
+                materials.bundle,
+                artifact,
+            ]
+        )
 
         self.run(*args)
 
@@ -243,17 +249,21 @@ class SigstoreClient:
         not be called directly.
         """
 
-        args = [
-            "verify",
-            "--signature",
-            materials.signature,
-            "--certificate",
-            materials.certificate,
-            "--certificate-identity",
-            CERTIFICATE_IDENTITY,
-            "--certificate-oidc-issuer",
-            CERTIFICATE_OIDC_ISSUER,
-        ]
+        args: list[str | os.PathLike] = ["verify"]
+        if self.staging:
+            args.append("--staging")
+        args.extend(
+            [
+                "--signature",
+                materials.signature,
+                "--certificate",
+                materials.certificate,
+                "--certificate-identity",
+                CERTIFICATE_IDENTITY,
+                "--certificate-oidc-issuer",
+                CERTIFICATE_OIDC_ISSUER,
+            ]
+        )
 
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", materials.trusted_root])
@@ -270,16 +280,19 @@ class SigstoreClient:
         This is an overload of `verify` for the bundle flow and should not be called
         directly.
         """
-
-        args = [
-            "verify-bundle",
-            "--bundle",
-            materials.bundle,
-            "--certificate-identity",
-            CERTIFICATE_IDENTITY,
-            "--certificate-oidc-issuer",
-            CERTIFICATE_OIDC_ISSUER,
-        ]
+        args: list[str | os.PathLike] = ["verify-bundle"]
+        if self.staging:
+            args.append("--staging")
+        args.extend(
+            [
+                "--bundle",
+                materials.bundle,
+                "--certificate-identity",
+                CERTIFICATE_IDENTITY,
+                "--certificate-oidc-issuer",
+                CERTIFICATE_OIDC_ISSUER,
+            ]
+        )
 
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", materials.trusted_root])


### PR DESCRIPTION
Main change here is the staging invocation: I'm proposing that a single action invocation only runs the testsuite once because 
* xfails becames painful if staging expected failures are not the same as prod (which seems like a normal thing at times).
* The test results are much clearer ("Staging conformance failure" is not as critical as "production conformance failure")

Other changes in this PR (from testing and reviewing for a hopefully near future release):
* run selftest daily (and on dispatch)
* update linter config to silence warnings
* update cli protocol doc and move `--staging` so it's not after the artifact filename

Fixes #130

I'll mark William a reviewer since we originally agreed to run test suite twice but  I think we may have been wrong.

--- 

For release Notes:

* The action now supports testing against Sigstore staging infrastructure: if your Sigstore client can be used with staging, please enable this by adding a second step to your workflow: see [README](https://github.com/sigstore/sigstore-conformance?tab=readme-ov-file#usage)