### PR TITLE
requirements: bump sigstore-protobuf-specs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest==7.1.3
 requests==2.31.0
 cryptography>=39
-sigstore-protobuf-specs~=0.2.0
+sigstore-protobuf-specs~=0.3.0


### PR DESCRIPTION
Bumps sigstore-protobuf-specs to `~= 0.3.0`, which includes v3 bundle support. Without this bump, anything in sigstore-python that constructs v3 bundles under the hood will fail (hooray for hidden version conflicts in Python environments!)