### PR TITLE
dev-requirements: enforce sigstore ~= 2.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sigstore
+sigstore ~= 2.0
 ruff
 black
 mypy


### PR DESCRIPTION
This *ought* to always resolve, but there's nothing preventing `pip` from selecting an older version without it.

h/t @segiddins