### PR TITLE
dev-requirements: switch to sigstore-python 3.x

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,7 +25,7 @@ jobs:
           cache: "pip"
 
       - name: install sigstore-python
-        run: pip install "sigstore ~= 2.0"
+        run: pip install "sigstore ~= 3.0"
 
       - name: conformance test sigstore-python
         uses: ./

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
           environment: ${{ matrix.sigstore-env }}
-          xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root test_verify_v_0_3"
+          xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ dev: env/pyvenv.cfg
 
 .PHONY: lint
 lint: env/pyvenv.cfg $(ALL_PY_SRCS)
-	./env/bin/python -m black $(ALL_PY_SRCS)
+	./env/bin/python -m ruff format $(ALL_PY_SRCS)
 	./env/bin/python -m ruff check --fix $(ALL_PY_SRCS)
 	./env/bin/python -m mypy action.py test/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sigstore ~= 2.1.3
+sigstore ~= 3.0
 ruff
 black
 mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 sigstore ~= 3.0
 ruff
-black
 mypy
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.1.3
-requests==2.32.0
+pytest~=7.1
+requests~=2.32
 cryptography>=39
 sigstore-protobuf-specs~=0.3.0

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-from test.client import BundleMaterials, SigstoreClient
-from test.conftest import _MakeMaterialsByType
 
 import pytest  # type: ignore
 from cryptography import x509
 from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import Bundle
+
+from test.client import BundleMaterials, SigstoreClient
+from test.conftest import _MakeMaterialsByType
 
 
 def test_verify(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:

--- a/test/test_signature_verify.py
+++ b/test/test_signature_verify.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from test.conftest import _MakeMaterials, _MakeMaterialsByType
 
 import pytest  # type: ignore
+
+from test.conftest import _MakeMaterials, _MakeMaterialsByType
 
 from .client import SignatureCertificateMaterials, SigstoreClient
 

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,6 +1,6 @@
-from test.conftest import _MakeMaterials
-
 import pytest  # type: ignore
+
+from test.conftest import _MakeMaterials
 
 from .client import SigstoreClient
 


### PR DESCRIPTION
This has been out for a while, let's see if this breaks any of the automation.