### PR TITLE
Conformance tests for CPython release signatures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check out latest CPython release metadata
+      uses: actions/checkout@v4
+      with:
+        repository: woodruffw/cpython-release-tracker
+        persist-credentials: false
+        path: cpython-release-tracker
+
     - name: Set up sigstore-conformance
       run: |
         # NOTE: Sourced, not executed as a script.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ runs:
         repository: woodruffw/cpython-release-tracker
         persist-credentials: false
         path: cpython-release-tracker
+        ref: 31c7721f29ae4181484ae9b399ecc5f04da947e1
 
     - name: Set up sigstore-conformance
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest~=7.1
+pytest-subtests
 requests~=2.32
 cryptography>=39
 sigstore-protobuf-specs~=0.3.0

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -14,7 +14,9 @@ fi
 
 # We expect cpython-release-tracker to have been checked out;
 # the unit tests expect to load its assets.
-[[ -d "${GITHUB_WORKSPACE}/cpython-release-tracker" ]] || die "cpython-release-tracker is not checked out!"
+if [[ ! -d "${GITHUB_WORKSPACE}/cpython-release-tracker" ]]; then
+  die "cpython-release-tracker is not checked out!"
+fi
 
 # Check the Python version, making sure it's new enough (3.7+)
 # The installation step immediately below will technically catch this,

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -12,6 +12,10 @@ if [[ "${0}" == "${BASH_SOURCE[0]}" ]]; then
   die "Internal error: setup harness was executed instead of being sourced?"
 fi
 
+# We expect cpython-release-tracker to have been checked out;
+# the unit tests expect to load its assets.
+[[ -d "${GITHUB_WORKSPACE}/cpython-release-tracker" ]] || die "cpython-release-tracker is not checked out!"
+
 # Check the Python version, making sure it's new enough (3.7+)
 # The installation step immediately below will technically catch this,
 # but doing it explicitly gives us the opportunity to produce a better

--- a/test/client.py
+++ b/test/client.py
@@ -67,6 +67,12 @@ class BundleMaterials(VerificationMaterials):
     trusted_root: Path
 
     @classmethod
+    def from_path(cls, bundle: Path) -> BundleMaterials:
+        mats = cls()
+        mats.bundle = bundle
+        return mats
+
+    @classmethod
     def from_input(cls, input: Path) -> BundleMaterials:
         mats = cls()
         mats.bundle = input.parent / f"{input.name}.sigstore.json"

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -378,7 +378,7 @@ def test_verify_cpython_release_bundles(subtests, client):
 
     def temp_bundle_path(bundle: dict) -> Path:
         # We let the system dispose of these after process teardown.
-        tmpfile = tempfile.NamedTemporaryFile(suffix=".sigstore.json", delete=False)
+        tmpfile = tempfile.NamedTemporaryFile(mode="w+t", suffix=".sigstore.json", delete=False)
         tmpfile.write(json.dumps(bundle))
         tmpfile.close()
 

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -318,6 +318,13 @@ def test_verify_cpython_release_bundles(subtests):
     if not cpython_release_dir.is_dir():
         pytest.skip("cpython-release-tracker data is not available")
 
-    releases = cpython_release_dir / "releases"
-    for release_path in releases.glob("*.json"):
-        json.loads(release_path.read_text())
+    _identities = json.loads((cpython_release_dir / "signing-identities.json").read_text())
+
+    versions = cpython_release_dir / "versions"
+    for version_path in versions.glob("*.json"):
+        version = json.loads(version_path.read_text())
+        for artifact in version:
+            bundle = artifact.get("sigstore")
+            if bundle:
+                with subtests.test(artifact["url"]):
+                    pass

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -364,7 +364,7 @@ def test_verify_cpython_release_bundles(subtests, client):
 
     identities = json.loads((cpython_release_dir / "signing-identities.json").read_text())
 
-    def version_path_to_identity(path: Path) -> dict[str, Any]:
+    def version_path_to_identity(path: Path) -> dict[str, Any] | None:
         # Transforms /foo/bar/versions/3.11.6.json into a suitable
         # verification identity.
 
@@ -374,7 +374,7 @@ def test_verify_cpython_release_bundles(subtests, client):
         # "3.11"
         version = ".".join(full_version.split(".")[0:2])
 
-        return next(ident for ident in identities if ident["Release"] == version)
+        return next([ident for ident in identities if ident["Release"] == version], None)
 
     def temp_bundle_path(bundle: dict) -> Path:
         # We let the system dispose of these after process teardown.
@@ -387,6 +387,9 @@ def test_verify_cpython_release_bundles(subtests, client):
     versions = cpython_release_dir / "versions"
     for version_path in versions.glob("*.json"):
         ident = version_path_to_identity(version_path)
+        if not ident:
+            continue
+
         version = json.loads(version_path.read_text())
         for artifact in version:
             bundle = artifact.get("sigstore")

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -1,3 +1,5 @@
+import json
+import os
 from pathlib import Path
 
 import pytest  # type: ignore
@@ -309,3 +311,13 @@ def test_verify_rejects_checkpoint_with_no_matching_key(
 
     with client.raises():
         client.verify(materials, input_path)
+
+
+def test_verify_cpython_release_bundles(subtests):
+    cpython_release_dir = Path(os.getenv("GITHUB_WORKSPACE")) / "cpython-release-tracker"
+    if not cpython_release_dir.is_dir():
+        pytest.skip("cpython-release-tracker data is not available")
+
+    releases = cpython_release_dir / "releases"
+    for release_path in releases.glob("*.json"):
+        json.loads(release_path.read_text())

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -374,7 +374,7 @@ def test_verify_cpython_release_bundles(subtests, client):
         # "3.11"
         version = ".".join(full_version.split(".")[0:2])
 
-        return next([ident for ident in identities if ident["Release"] == version], None)
+        return next((ident for ident in identities if ident["Release"] == version), None)
 
     def temp_bundle_path(bundle: dict) -> Path:
         # We let the system dispose of these after process teardown.

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -325,6 +325,7 @@ def test_verify_cpython_release_bundles(subtests):
         version = json.loads(version_path.read_text())
         for artifact in version:
             bundle = artifact.get("sigstore")
-            if bundle:
-                with subtests.test(artifact["url"]):
-                    pass
+            if not bundle:
+                continue
+            with subtests.test(artifact["url"]):
+                pass


### PR DESCRIPTION
~~WIP.~~

This adds conformance suite tests for CPython's releases, which use Sigstore bundles. The idea is to continuously check whether CPython releases are verifiable by multiple clients.

