### PR TITLE
Support verifying digests in addition to artifacts

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,7 +25,7 @@ jobs:
           cache: "pip"
 
       - name: install sigstore-python
-        run: pip install "sigstore ~= 3.0"
+        run: pip install "sigstore >= 3.3.0, < 4.0"
 
       - name: conformance test sigstore-python
         uses: ./

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -77,7 +77,7 @@ ${ENTRYPOINT} verify [--staging] --signature FILE --certificate FILE --certifica
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE
+${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] [--verify-digest] FILE_OR_DIGEST
 ```
 
 | Option | Description |
@@ -87,4 +87,5 @@ ${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDE
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
 | `--trusted-root` | The path of the custom trusted root to use to verify the bundle |
-| `FILE` | The path to the artifact to verify |
+| `--verify-digest` | Presence indicates client should interpret `FILE_OR_DIGEST` as a digest. |
+| `FILE_OR_DIGEST` | The path to the artifact to verify, or its digest. The digest should start with the `sha256:` prefix. |

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -15,6 +15,8 @@ SUBCMD_REPLACEMENTS = {
 ARG_REPLACEMENTS = {
     "--certificate-identity": "--cert-identity",
     "--certificate-oidc-issuer": "--cert-oidc-issuer",
+    # sigstore-python detects if the input is a file path or a digest without needing a flag
+    "--verify-digest": None,
 }
 
 # Trim the script name.
@@ -43,5 +45,7 @@ else:
 
 # Replace incompatible flags.
 command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
+# Remove unneeded flags
+command = [arg for arg in command if arg is not None]
 
 os.execvp("sigstore", command)

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -5,10 +5,14 @@ from cryptography import x509
 from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import Bundle
 
 from test.client import BundleMaterials, SigstoreClient
-from test.conftest import _MakeMaterialsByType
+from test.conftest import _MakeMaterialsByType, _VerifyBundle
 
 
-def test_verify(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify(
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
+) -> None:
     """
     Test the happy path of verification
     """
@@ -17,10 +21,14 @@ def test_verify(client: SigstoreClient, make_materials_by_type: _MakeMaterialsBy
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.good.sigstore.json")
 
-    client.verify(materials, input_path)
+    verify_bundle(materials, input_path)
 
 
-def test_verify_v_0_3(client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType) -> None:
+def test_verify_v_0_3(
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
+) -> None:
     """
     Test the happy path of verification of a v0.3 bundle
     """
@@ -29,11 +37,13 @@ def test_verify_v_0_3(client: SigstoreClient, make_materials_by_type: _MakeMater
     input_path, materials = make_materials_by_type("a.txt", BundleMaterials)
     materials.bundle = Path("a.txt.good.v0.3.sigstore")
 
-    client.verify(materials, input_path)
+    verify_bundle(materials, input_path)
 
 
 def test_verify_dsse_bundle_with_trust_root(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Test the happy path of verification for DSSE bundle w/ custom trust root
@@ -43,11 +53,13 @@ def test_verify_dsse_bundle_with_trust_root(
     materials.bundle = Path("d.txt.good.sigstore.json")
     materials.trusted_root = Path("trusted_root.d.json")
 
-    client.verify(materials, input_path)
+    verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_root(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle that contains a root certificate.
@@ -57,12 +69,14 @@ def test_verify_rejects_root(
     input_path, materials = make_materials_by_type("has_root_in_chain.txt", BundleMaterials)
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 @pytest.mark.signing
 def test_sign_does_not_produce_root(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client does not produce a bundle that contains a root
@@ -94,7 +108,9 @@ def test_sign_does_not_produce_root(
 
 
 def test_verify_rejects_staging_cert(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle that doesn't match trust root.
@@ -105,11 +121,13 @@ def test_verify_rejects_staging_cert(
     materials.bundle = Path("a.txt.staging.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_invalid_set(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle with a signed entry timestamp from
@@ -121,11 +139,13 @@ def test_verify_rejects_invalid_set(
     materials.bundle = Path("a.txt.invalid_set.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_invalid_signature(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle with a modified signature.
@@ -136,11 +156,13 @@ def test_verify_rejects_invalid_signature(
     materials.bundle = Path("a.txt.invalid_signature.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_invalid_key(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle with a modified public key in the
@@ -152,11 +174,13 @@ def test_verify_rejects_invalid_key(
     materials.bundle = Path("a.txt.invalid_key.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_invalid_inclusion_proof(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle with an old inclusion proof
@@ -167,11 +191,13 @@ def test_verify_rejects_invalid_inclusion_proof(
     materials.bundle = Path("a.txt.invalid_inclusion_proof.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_different_materials(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle for different materials.
@@ -182,11 +208,13 @@ def test_verify_rejects_different_materials(
     materials.bundle = Path("a.txt.good.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_expired_certificate(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the certificate was issued
@@ -198,11 +226,13 @@ def test_verify_rejects_expired_certificate(
     materials.trusted_root = Path("trusted_root.d.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_missing_inclusion_proof(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a v0.2 bundle if the TLog entry does NOT
@@ -214,11 +244,13 @@ def test_verify_rejects_missing_inclusion_proof(
     materials.trusted_root = Path("trusted_root.d.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_bad_tlog_timestamp(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the TLog entry contains a
@@ -231,11 +263,13 @@ def test_verify_rejects_bad_tlog_timestamp(
     materials.trusted_root = Path("trusted_root.d.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_bad_tlog_entry(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the body of the TLog entry does
@@ -247,11 +281,13 @@ def test_verify_rejects_bad_tlog_entry(
     materials.trusted_root = Path("trusted_root.d.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_bad_tsa_timestamp(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the TSA timestamp falls outside
@@ -263,11 +299,13 @@ def test_verify_rejects_bad_tsa_timestamp(
     materials.trusted_root = Path("trusted_root.d.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_bad_checkpoint(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the checkpoint signature is
@@ -278,11 +316,13 @@ def test_verify_rejects_bad_checkpoint(
     materials.bundle = Path("a.txt.checkpoint_invalid_signature.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_valid_but_mismatched_checkpoint(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the checkpoint self consistent
@@ -293,11 +333,13 @@ def test_verify_rejects_valid_but_mismatched_checkpoint(
     materials.bundle = Path("a.txt.checkpoint_wrong_roothash.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)
 
 
 def test_verify_rejects_checkpoint_with_no_matching_key(
-    client: SigstoreClient, make_materials_by_type: _MakeMaterialsByType
+    client: SigstoreClient,
+    make_materials_by_type: _MakeMaterialsByType,
+    verify_bundle: _VerifyBundle,
 ) -> None:
     """
     Check that the client rejects a bundle if the checkpoint signature
@@ -308,4 +350,4 @@ def test_verify_rejects_checkpoint_with_no_matching_key(
     materials.bundle = Path("a.txt.checkpoint_bad_keyhint.sigstore.json")
 
     with client.raises():
-        client.verify(materials, input_path)
+        verify_bundle(materials, input_path)

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,6 +1,6 @@
 import pytest  # type: ignore
 
-from test.conftest import _MakeMaterials, identity_token
+from test.conftest import _MakeMaterials
 
 from .client import SigstoreClient
 


### PR DESCRIPTION
This PR adds support for verifying hashes (instead of files) to the CLI protocol (only when verifying bundles).

 It also adapts the `sigstore-python-conformance` helper to support it, given `sigstore-python` supports verifying hashes [since v3.3.0](https://github.com/sigstore/sigstore-python/releases/tag/v3.3.0).

All the existing bundle verification tests have been parametrized to also test the hash verification, in addition to the existing `Path` (file) verification.

This closes https://github.com/sigstore/sigstore-conformance/issues/157

cc @woodruffw 

