### PR TITLE
action: bump cpython-release-tracker ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         repository: woodruffw/cpython-release-tracker
         persist-credentials: false
         path: cpython-release-tracker
-        ref: 31c7721f29ae4181484ae9b399ecc5f04da947e1
+        ref: 9eb74dae56e55433ee03c7283dc013645d5d8c4e
 
     - name: Set up sigstore-conformance
       run: |


### PR DESCRIPTION
For the latest releases: https://github.com/woodruffw/cpython-release-tracker/pull/5

I need to figure out a good way to automate this PR as well.