### PR TITLE
Remove --verify-digest flag

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -77,7 +77,7 @@ ${ENTRYPOINT} verify [--staging] --signature FILE --certificate FILE --certifica
 #### Bundle flow
 
 ```console
-${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] [--verify-digest] FILE_OR_DIGEST
+${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE_OR_DIGEST
 ```
 
 | Option | Description |
@@ -87,5 +87,4 @@ ${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDE
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
 | `--trusted-root` | The path of the custom trusted root to use to verify the bundle |
-| `--verify-digest` | Presence indicates client should interpret `FILE_OR_DIGEST` as a digest. |
 | `FILE_OR_DIGEST` | The path to the artifact to verify, or its digest. The digest should start with the `sha256:` prefix. |

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -15,8 +15,6 @@ SUBCMD_REPLACEMENTS = {
 ARG_REPLACEMENTS = {
     "--certificate-identity": "--cert-identity",
     "--certificate-oidc-issuer": "--cert-oidc-issuer",
-    # sigstore-python detects if the input is a file path or a digest without needing a flag
-    "--verify-digest": None,
 }
 
 # Trim the script name.
@@ -45,7 +43,5 @@ else:
 
 # Replace incompatible flags.
 command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
-# Remove unneeded flags
-command = [arg for arg in command if arg is not None]
 
 os.execvp("sigstore", command)

--- a/test/client.py
+++ b/test/client.py
@@ -325,7 +325,6 @@ class SigstoreClient:
                 CERTIFICATE_IDENTITY,
                 "--certificate-oidc-issuer",
                 CERTIFICATE_OIDC_ISSUER,
-                "--verify-digest",
             ]
         )
 

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -412,7 +412,6 @@ def test_verify_cpython_release_bundles(subtests, client):
                         ident["Release manager"],
                         "--certificate-oidc-issuer",
                         ident["OIDC Issuer"],
-                        "--verify-digest",
                         f"sha256:{sha256}",
                     )
                 except ClientFail as e:


### PR DESCRIPTION
fixes #161, this doesn't remove the feature developed in #158, only removes the `--verify-digest` flag instead making clients parse the argument to determine in the action.