### PR TITLE
cli_protocol: clarify FILE_OR_DIGEST

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -87,4 +87,4 @@ ${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDE
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
 | `--trusted-root` | The path of the custom trusted root to use to verify the bundle |
-| `FILE_OR_DIGEST` | The path to the artifact to verify, or its digest. The digest should start with the `sha256:` prefix. |
+| `FILE_OR_DIGEST` | The path to the artifact to verify, or its digest. The digest should start with the `sha256:` prefix, should be the right length for a hexadecimal SHA-256 digest, and should not be a path on disk. If any of those conditions are not met, the input should be interpreted as a filepath instead. |


### PR DESCRIPTION
@phillmv pointed out that the current conformance definition is a little ambiguous, and can be tripped up on clients like `gh` (which emits `sha256:hash.jsonl` files by default). This clarifies it to say that anything that isn't *exactly* a hash should be intepreted as a filepath.