### PR TITLE
Create provenance-generator

### DIFF
--- a/.github/workflows/provenance-generator
+++ b/.github/workflows/provenance-generator
@@ -1,0 +1,18 @@
+name: Generate Provenance
+# a workflow to generate provnenance objects for inclusion in this test suite
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  generate-attestation:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
+      with:
+        subject-path: ./test/assets/a.txt


### PR DESCRIPTION
Create provenance for a.txt from within this repo

This is workflow dispatch only. It will generate official github provenance which can be copied into the test/assets directory for use with dsse-intoto bundle tests.