### PR TITLE
test: don't assume GITHUB_WORKSPACE

### DIFF
--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -378,9 +378,12 @@ def test_verify_rejects_mismatched_hashedrekord(
 
 
 def test_verify_cpython_release_bundles(subtests, client):
-    cpython_release_dir = Path(os.getenv("GITHUB_WORKSPACE")) / "cpython-release-tracker"
-    if not cpython_release_dir.is_dir():
-        pytest.skip("cpython-release-tracker data is not available")
+    if gh_workspace := os.getenv("GITHUB_WORKSPACE"):
+        cpython_release_dir = Path(gh_workspace) / "cpython-release-tracker"
+        if not cpython_release_dir.is_dir():
+            pytest.skip("cpython-release-tracker data is not available")
+    else:
+        pytest.skip("GITHUB_WORKSPACE not set")
 
     identities = json.loads((cpython_release_dir / "signing-identities.json").read_text())
 


### PR DESCRIPTION
This should make local use slightly less painful, since users won't need to do workarounds like `GITHUB_WORKSPACE=/tmp` to have these skip properly.

A larger refactor here would be to allow users to configure this path wholly, so that people can also easily run the CPython bundle tests locally.

CC @bdehamer 