### PR TITLE
add skip-cpython-release-tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,10 @@ jobs:
   selftest:
     strategy:
       matrix:
-        sigstore-env: [production, staging]
+        include:
+          - { sigstore-env: production, skip-cpython-release-tests: false }
+          - { sigstore-env: production, skip-cpython-release-tests: true }
+          - { sigstore-env: staging, skip-cpython-release-tests: false }
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -31,5 +34,6 @@ jobs:
         uses: ./
         with:
           entrypoint: ${{ github.workspace }}/sigstore-python-conformance
+          skip-cpython-release-tests: ${{ matrix.skip-cpython-release-tests }}
           environment: ${{ matrix.sigstore-env }}
           xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -24,11 +24,11 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.x"
           cache: "pip"
 
       - name: install sigstore-python
-        run: pip install "sigstore >= 3.3.0, < 4.0"
+        run: pip install "sigstore >= 3.5.0, < 4.0"
 
       - name: conformance test sigstore-python
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "skip tests that involve signing (default false)"
     required: false
     default: "false"
+  skip-cpython-release-tests:
+    description: "skip all CPython Sigstore bundle tests"
+    required: false
+    default: "false"
   environment:
     description: "'production' (default) or 'staging'"
     required: false
@@ -50,5 +54,6 @@ runs:
         GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT: "${{ inputs.entrypoint }}"
         GHA_SIGSTORE_CONFORMANCE_INTERNAL_BE_CAREFUL_DEBUG: "${{ inputs.internal-be-careful-debug }}"
         GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING: "${{ inputs.skip-signing }}"
+        GHA_SIGSTORE_CONFORMANCE_SKIP_CPYTHON_RELEASE_TESTS: "${{ inputs.skip-cpython-release-tests }}"
         GHA_SIGSTORE_CONFORMANCE_XFAIL: "${{ inputs.xfail }}"
       shell: bash

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -11,6 +11,12 @@ from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import Bundle
 from test.client import BundleMaterials, ClientFail, SigstoreClient
 from test.conftest import _MakeMaterialsByType, _VerifyBundle
 
+SKIP_CPYTHON_RELEASE_TESTS = (
+    os.getenv("GHA_SIGSTORE_CONFORMANCE_SKIP_CPYTHON_RELEASE_TESTS", "false") != "false"
+)
+
+GITHUB_WORKSPACE = os.getenv("GITHUB_WORKSPACE")
+
 
 def test_verify(
     client: SigstoreClient,
@@ -377,13 +383,12 @@ def test_verify_rejects_mismatched_hashedrekord(
         verify_bundle(materials, input_path)
 
 
+@pytest.mark.skipif(SKIP_CPYTHON_RELEASE_TESTS, "CPython release bundle tests explicitly skipped")
+@pytest.mark.skipif(not GITHUB_WORKSPACE, "GITHUB_WORKSPACE not set")
 def test_verify_cpython_release_bundles(subtests, client):
-    if gh_workspace := os.getenv("GITHUB_WORKSPACE"):
-        cpython_release_dir = Path(gh_workspace) / "cpython-release-tracker"
-        if not cpython_release_dir.is_dir():
-            pytest.skip("cpython-release-tracker data is not available")
-    else:
-        pytest.skip("GITHUB_WORKSPACE not set")
+    cpython_release_dir = Path(GITHUB_WORKSPACE) / "cpython-release-tracker"
+    if not cpython_release_dir.is_dir():
+        pytest.skip("cpython-release-tracker data is not available")
 
     identities = json.loads((cpython_release_dir / "signing-identities.json").read_text())
 

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -383,8 +383,10 @@ def test_verify_rejects_mismatched_hashedrekord(
         verify_bundle(materials, input_path)
 
 
-@pytest.mark.skipif(SKIP_CPYTHON_RELEASE_TESTS, "CPython release bundle tests explicitly skipped")
-@pytest.mark.skipif(not GITHUB_WORKSPACE, "GITHUB_WORKSPACE not set")
+@pytest.mark.skipif(
+    SKIP_CPYTHON_RELEASE_TESTS, reason="CPython release bundle tests explicitly skipped"
+)
+@pytest.mark.skipif(not GITHUB_WORKSPACE, reason="GITHUB_WORKSPACE not set")
 def test_verify_cpython_release_bundles(subtests, client):
     cpython_release_dir = Path(GITHUB_WORKSPACE) / "cpython-release-tracker"
     if not cpython_release_dir.is_dir():


### PR DESCRIPTION
This adds an input that allows the (hefty) CPython release bundle tests to be outright skipped. It also adds a selftest matrix configuration to ensure the input works as expected.