### PR TITLE
handle different certificate fields correctly

### DIFF
--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -105,8 +105,14 @@ def test_sign_does_not_produce_root(
     bundle = Bundle().from_json(bundle_contents)
 
     # Iterate over our cert chain and check for roots.
-    certs = bundle.verification_material.x509_certificate_chain
-    for x509cert in certs.certificates:
+    if bundle.verification_material.is_set("x509_certificate_chain"):
+        certs = bundle.verification_material.x509_certificate_chain.certificates
+    elif bundle.verification_material.is_set("certificate"):
+        certs = [bundle.verification_material.certificate]
+    else:
+        assert False, "expected certs in either `x509_certificate_chain` or `certificate`"
+
+    for x509cert in certs:
         cert = x509.load_der_x509_certificate(x509cert.raw_bytes)
 
         try:


### PR DESCRIPTION
~~WIP; still root causing the failure that surfaced this.~~

This checks both `x509_certificate_chain` and `certificate` in the `test_sign_does_not_produce_root` test, since clients can place bundled certificates in either (and as of v3 bundles, are required to use the latter instead of the former).

xref https://github.com/sigstore/sigstore-go/actions/runs/12697653217

CC @haydentherapper 