### PR TITLE
Pin dependencies, setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pytest~=7.1
-pytest-subtests
-requests~=2.32
-cryptography>=39
-sigstore-protobuf-specs~=0.3.0
+pytest==8.3.4
+pytest-subtests==0.14.1
+requests==2.32.3
+cryptography==44.0.0
+sigstore-protobuf-specs==0.3.2


### PR DESCRIPTION
Purpose here is to make the test suite reproducible for action users (test suite dependency updates should not break workflows). At the moment I believe the action is broken for everyone except sigstore-python and the selftest here...

* Pin dependencies by exact version
* Setup dependabot: update once a month

Fixes #178, but I will file another issue about installing sigstore-python in a virtual env of its own