### PR TITLE
Always show test durations

### DIFF
--- a/action.py
+++ b/action.py
@@ -27,7 +27,7 @@ def _debug(msg):
 
 
 def _sigstore_conformance(environment: str) -> int:
-    args = []
+    args = ["--durations=0"]
 
     if _DEBUG:
         args.extend(["-s", "-vv", "--showlocals"])


### PR DESCRIPTION
#### Summary
Configure pytest to always print test durations per https://github.com/sigstore/sigstore-conformance/issues/188#issuecomment-2610145491.

#### Release Note
NONE

#### Documentation
NONE
