### PR TITLE
cpython verify: Only verify one artifact per release

### DIFF
--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -445,10 +445,10 @@ def test_verify_cpython_release_bundles(subtests, client):
 
         version = json.loads(version_path.read_text())
         for artifact in version:
+            bundle = artifact.get("sigstore")
+            if not bundle:
+                continue
             with subtests.test(artifact["url"]):
-                bundle = artifact.get("sigstore")
-                if not bundle:
-                    continue
 
                 bundle_path = temp_bundle_path(bundle)
                 sha256 = artifact["sha256"]
@@ -469,6 +469,9 @@ def test_verify_cpython_release_bundles(subtests, client):
                     )
                 except ClientFail as e:
                     pytest.fail(f"verify for {artifact['url']} failed: {e}")
+
+                # One verification per release is enough
+                break
 
 
 def test_verify_in_toto_in_dsse_envelope(


### PR DESCRIPTION
This should improve performance by a lot but should not affect coverage (since all artifacts in one release are likely very similar).

Changes in the PR:
* non-sigstore signed cpython releases are not counted as subtests (this likely did not affect performance in any way but seems like a better way to count)
* only one artifact per cpython release is tested

We're left with 70 cpython release tests (down from 1633). The selftest runtime went from 330 seconds to 90 seconds, I think sigstore-java will get even more benefit from this. 
