### PR TITLE
Install dependencies in a virtualenv in the action too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Run sigstore-conformance
       id: sigstore-conformance
       run: |
-        ${{ github.action_path }}/action.py
+        ./sigstore-conformance-env/bin/python ${{ github.action_path }}/action.py
       env:
         GHA_SIGSTORE_CONFORMANCE_ENVIRONMENT: "${{ inputs.environment }}"
         GHA_SIGSTORE_CONFORMANCE_ENTRYPOINT: "${{ inputs.entrypoint }}"

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -28,4 +28,5 @@ min_vers=$(cut -d '.' -f2 <<< "${vers}")
 
 [[ "${maj_vers}" == "3" && "${min_vers}" -ge 7 ]] || die "Bad Python version: ${vers}"
 
-python -m pip install --requirement "${GITHUB_ACTION_PATH}/requirements.txt"
+python3 -m venv sigstore-conformance-env
+./sigstore-conformance-env/bin/python -m pip install --requirement "${GITHUB_ACTION_PATH}/requirements.txt"


### PR DESCRIPTION
* This makes sure we don't pollute the main Python environment which is good for at least sigstore-python in https://github.com/sigstore/sigstore-python/pull/1276
* I'm sure there are neater ways to handle this but this seems to work: The client-under-test and the test suite can now successfully use different sigstore-protobuf-specs versions