### PR TITLE
Prepare for 0.0.18 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ client-under-test [CLI protocol](docs/cli_protocol.md).
           # insert your client installation steps here
 
           # Run tests against production Sigstore environment
-          - uses: sigstore/sigstore-conformance@v0.0.17
+          - uses: sigstore/sigstore-conformance@v0.0.18
             with:
               entrypoint: my-conformance-client
 
           # Run tests against staging Sigstore environment
-          - uses: sigstore/sigstore-conformance@v0.0.17
+          - uses: sigstore/sigstore-conformance@v0.0.18
             with:
               entrypoint: my-conformance-client
               environment: staging


### PR DESCRIPTION
Changelog is
* Use current sigstore-protobuf-specs
* Make sure the test suite is installed in a separate environment in both Makefile and the action

--- 

This release is a little debatable: it contains very little that is useful for other users but it does fix bugs that affect sigstore-python (blocks sigstore/sigstore-python#1276)

The alternative to this release is that we use a non-released conformance in sigstore-python for now and remember to update later: https://github.com/jku/sigstore-python/commit/e28b7656d40e0e28c05959e8aa8aff8e3d367ee6

@woodruffw  @loosebazooka  I can do the release tag here but am fine either way if you have opinions.