### PR TITLE
build: Avoid new pip to workaround pip-tools issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all:
 
 env/bootstrap: dev-requirements.txt
 	python3 -m venv env
-	./env/bin/python -m pip install --upgrade pip
+	./env/bin/python -m pip install --upgrade 'pip < 25.1' # workaround #206
 	./env/bin/python -m pip install --requirement dev-requirements.txt
 	touch env/bootstrap
 


### PR DESCRIPTION
pip-tools is currently incompatible with pip 25.1
(https://github.com/jazzband/pip-tools/issues/2176). Work around by avoiding new pip for now.

Fixes #206

This should unblock the other PRs currently failing CI checks. I'll file an issue about reverting this once the pip-tools issue is fixed

