### PR TITLE
workflows: Set permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "10 10 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   selftest:
     strategy:


### PR DESCRIPTION
This is best practice and silences a code scan alert.
