### PR TITLE
selftest: Complete the fake signingconfig

### DIFF
--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -18,9 +18,19 @@ trust_config = {
     "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
     "signingConfig": {
         "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
-        "caUrls": [{"url": "https://fulcio.example.com"}],
+        "caUrls": [{
+            "url": "https://fulcio.example.com",
+            "majorApiVersion": 1,
+            "operator": "",
+            "validFor": {"start": "1970-01-01T01:01:01Z"}
+        }],
         "oidcUrls": [],
-        "rekorTlogUrls": [{"url": "https://rekor.example.com"}],
+        "rekorTlogUrls": [{
+            "url": "https://rekor.example.com",
+            "majorApiVersion": 1,
+            "operator": "",
+            "validFor": {"start": "1970-01-01T01:01:01Z"}
+        }],
         "tsaUrls": [],
         "rekorTlogConfig": {"selector": "ANY"},
         "tsaConfig": {"selector": "ANY"},


### PR DESCRIPTION
This signingconfig is never used but new sigstore-python is more strict about the content.

leaving draft while I test that this really works