### PR TITLE
Support --signing-config in CLI, test for rekor2 signing

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -40,6 +40,8 @@ ${ENTRYPOINT} sign-bundle [--staging] --identity-token TOKEN --bundle FILE FILE
 | `--staging`        | Presence indicates client should use Sigstore staging infrastructure |
 | `--identity-token` | The OIDC identity token to use |
 | `--bundle FILE` | The path to write the bundle to |
+| `--trusted-root TRUSTROOT` | Optional path to a custom trusted root to use to verify the bundle |
+| `--signing-config SIGNINGCONFIG` | Optional path to a custom signing config to use to verify the bundle |
 | `FILE` | The artifact to sign |
 
 ### Verify
@@ -56,5 +58,5 @@ ${ENTRYPOINT} verify-bundle [--staging] --bundle FILE --certificate-identity IDE
 | `--bundle FILE` | The path to the Sigstore bundle to verify |
 | `--certificate-identity IDENTITY` | The expected identity in the signing certificate's SAN extension |
 | `--certificate-oidc-issuer URL` | The expected OIDC issuer for the signing certificate |
-| `--trusted-root` | The path of the custom trusted root to use to verify the bundle |
+| `--trusted-root TRUSTROOT` | Optional path to a custom trusted root to use to verify the bundle |
 | `FILE_OR_DIGEST` | The path to the artifact to verify, or its digest. The digest should start with the `sha256:` prefix, should be the right length for a hexadecimal SHA-256 digest, and should not be a path on disk. If any of those conditions are not met, the input should be interpreted as a filepath instead. |

--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -41,7 +41,7 @@ ${ENTRYPOINT} sign-bundle [--staging] --identity-token TOKEN --bundle FILE FILE
 | `--identity-token` | The OIDC identity token to use |
 | `--bundle FILE` | The path to write the bundle to |
 | `--trusted-root TRUSTROOT` | Optional path to a custom trusted root to use to verify the bundle |
-| `--signing-config SIGNINGCONFIG` | Optional path to a custom signing config to use to verify the bundle |
+| `--signing-config SIGNINGCONFIG` | Optional path to a custom signing config to use when signing |
 | `FILE` | The artifact to sign |
 
 ### Verify

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -70,7 +70,8 @@ if "--staging" in fixed_args:
     command.append("--staging")
     fixed_args.remove("--staging")
 
-# We may get "--trusted-root" as argument but sigstore-python wants "--trust-config":
+# We may get "--trusted-root" and "--signing-config" as argument but sigstore-python
+# wants "--trust-config":
 trusted_root_path = None
 with suppress(ValueError):
     i = fixed_args.index("--trusted-root")
@@ -78,12 +79,25 @@ with suppress(ValueError):
     fixed_args.pop(i)
     fixed_args.pop(i)
 
+signing_config_path = None
+with suppress(ValueError):
+    i = fixed_args.index("--signing-config")
+    signing_config_path = fixed_args[i + 1]
+    fixed_args.pop(i)
+    fixed_args.pop(i)
+
+
 # If we did get a trustedroot, write a matching trustconfig into a temp file
+# Use given signingconfig if possible, otherwise use the fake one in template
 with NamedTemporaryFile(mode="wt") as temp_file:
     if trusted_root_path is not None:
         with open(trusted_root_path) as f:
             trusted_root = json.load(f)
         trust_config["trustedRoot"] = trusted_root
+        if signing_config_path is not None:
+            with open(signing_config_path) as f:
+                signing_config = json.load(f)
+            trust_config["signingConfig"] = signing_config
 
         json.dump(trust_config, temp_file)
         temp_file.flush()

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -18,19 +18,23 @@ trust_config = {
     "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
     "signingConfig": {
         "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
-        "caUrls": [{
-            "url": "https://fulcio.example.com",
-            "majorApiVersion": 1,
-            "operator": "",
-            "validFor": {"start": "1970-01-01T01:01:01Z"}
-        }],
+        "caUrls": [
+            {
+                "url": "https://fulcio.example.com",
+                "majorApiVersion": 1,
+                "operator": "",
+                "validFor": {"start": "1970-01-01T01:01:01Z"},
+            }
+        ],
         "oidcUrls": [],
-        "rekorTlogUrls": [{
-            "url": "https://rekor.example.com",
-            "majorApiVersion": 1,
-            "operator": "",
-            "validFor": {"start": "1970-01-01T01:01:01Z"}
-        }],
+        "rekorTlogUrls": [
+            {
+                "url": "https://rekor.example.com",
+                "majorApiVersion": 1,
+                "operator": "",
+                "validFor": {"start": "1970-01-01T01:01:01Z"},
+            }
+        ],
         "tsaUrls": [],
         "rekorTlogConfig": {"selector": "ANY"},
         "tsaConfig": {"selector": "ANY"},
@@ -115,8 +119,6 @@ with NamedTemporaryFile(mode="wt") as temp_file:
         raise ValueError(f"unsupported subcommand: {subcommand}")
 
     # Replace incompatible flags.
-    command.extend(
-        ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args
-    )
+    command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
 
     os.execvp(SIGSTORE_BINARY, command)

--- a/test/assets/rekor2_signing_config.json
+++ b/test/assets/rekor2_signing_config.json
@@ -1,0 +1,66 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstage.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-14T21:38:40Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstage.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-16T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://log2025-alpha2.rekor.sigstage.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2025-08-20T07:24:08Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://log2025-alpha1.rekor.sigstage.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2025-05-07T12:00:00Z",
+        "end": "2025-08-20T07:24:08Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://rekor.sigstage.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.sigstage.dev/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-09T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}

--- a/test/assets/rekor2_trusted_root.json
+++ b/test/assets/rekor2_trusted_root.json
@@ -1,0 +1,138 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+  "tlogs": [
+    {
+      "baseUrl": "https://rekor.sigstage.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDODRU688UYGuy54mNUlaEBiQdTE9nYLr0lg6RXowI/QV/RE1azBn4Eg5/2uTOMbhB1/gfcHzijzFi9Tk+g1Prg==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-01-12T11:53:27Z"
+        }
+      },
+      "logId": {
+        "keyId": "0y8wo8MtY5wrdiIFohx7sHeI5oKDpK5vQhGHI6G+pJY="
+      }
+    },
+    {
+      "baseUrl": "https://log2025-alpha1.rekor.sigstage.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MCowBQYDK2VwAyEAPn+AREHoBaZ7wgS1zBqpxmLSGnyhxXj4lFxSdWVB8o8=",
+        "keyDetails": "PKIX_ED25519",
+        "validFor": {
+          "start": "2025-04-16T00:00:00Z",
+          "end": "2025-09-04T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "8w1amZ2S5mJIQkQmPxdMuOrL/oJkvFg9MnQXmeOCXck="
+      }
+    },
+    {
+      "baseUrl": "https://log2025-alpha2.rekor.sigstage.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MCowBQYDK2VwAyEAkrA8Ou2FtN7kYXCP/lpvF8vQrvh4nj+91+PWOGGzfGc=",
+        "keyDetails": "PKIX_ED25519",
+        "validFor": {
+          "start": "2025-08-08T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "KfSiSX2iRLyhK62SUVL47vVcqqRx/RAewpKJm8IdZTo="
+      }
+    }
+  ],
+  "certificateAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstage.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICGTCCAaCgAwIBAgITJta/okfgHvjabGm1BOzuhrwA1TAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIyMDQxNDIxMzg0MFoXDTMyMDMyMjE2NTA0NVowNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAASosAySWJQ/tK5r8T5aHqavk0oI+BKQbnLLdmOMRXHQF/4Hx9KtNfpcdjH9hNKQSBxSlLFFN3tvFCco0qFBzWYwZtsYsBe1l91qYn/9VHFTaEVwYQWIJEEvrs0fvPuAqjajezB5MA4GA1UdDwEB/wQEAwIBBjATBgNVHSUEDDAKBggrBgEFBQcDAzASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBRxhjCmFHxib/n31vQFGn9f/+tvrDAfBgNVHSMEGDAWgBT/QjK6aH2rOnCv3AzUGuI+h49mZTAKBggqhkjOPQQDAwNnADBkAjAM1lbKkcqQlE/UspMTbWNo1y2TaJ44tx3l/FJFceTSdDZ+0W1OHHeU4twie/lq8XgCMHQxgEv26xNNiAGyPXbkYgrDPvbOqp0UeWX4mJnLSrBr3aN/KX1SBrKQu220FmVL0Q=="
+          },
+          {
+            "rawBytes": "MIIB9jCCAXugAwIBAgITDdEJvluliE0AzYaIE4jTMdnFTzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIyMDMyNTE2NTA0NloXDTMyMDMyMjE2NTA0NVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABMo9BUNk9QIYisYysC24+2OytoV72YiLonYcqR3yeVnYziPt7Xv++CYE8yoCTiwedUECCWKOcvQKRCJZb9ht4Hzy+VvBx36hK+C6sECCSR0x6pPSiz+cTk1f788ZjBlUZaNjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFP9CMrpofas6cK/cDNQa4j6Hj2ZlMB8GA1UdIwQYMBaAFP9CMrpofas6cK/cDNQa4j6Hj2ZlMAoGCCqGSM49BAMDA2kAMGYCMQD+kojuzMwztNay9Ibzjuk//ZL5m6T2OCsm45l1lY004pcb984L926BowodoirFMcMCMQDIJtFHhP/1D3a+M3dAGomOb6O4CmTry3TTPbPsAFnv22YA0Y+P21NVoxKDjdu0tkw="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2022-04-14T21:38:40Z"
+      }
+    }
+  ],
+  "ctlogs": [
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/test",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MIICCgKCAgEA27A2MPQXm0I0v7/Ly5BIauDjRZF5Jor9vU+QheoE2UIIsZHcyYq3slHzSSHy2lLj1ZD2d91CtJ492ZXqnBmsr4TwZ9jQ05tW2mGIRI8u2DqN8LpuNYZGz/f9SZrjhQQmUttqWmtu3UoLfKz6NbNXUnoo+NhZFcFRLXJ8VporVhuiAmL7zqT53cXR3yQfFPCUDeGnRksnlhVIAJc3AHZZSHQJ8DEXMhh35TVv2nYhTI3rID7GwjXXw4ocz7RGDD37ky6p39Tl5NB71gT1eSqhZhGHEYHIPXraEBd5+3w9qIuLWlp5Ej/K6Mu4ELioXKCUimCbwy+Cs8UhHFlqcyg4AysOHJwIadXIa8LsY51jnVSGrGOEBZevopmQPNPtyfFY3dmXSS+6Z3RD2Gd6oDnNGJzpSyEk410Ag5uvNDfYzJLCWX9tU8lIxNwdFYmIwpd89HijyRyoGnoJ3entd63cvKfuuix5r+GHyKp1Xm1L5j5AWM6P+z0xigwkiXnt+adexAl1J9wdDxv/pUFEESRF4DG8DFGVtbdH6aR1A5/vD4krO4tC1QYUSeyL5Mvsw8WRqIFHcXtgybtxylljvNcGMV1KXQC8UFDmpGZVDSHx6v3e/BHMrZ7gjoCCfVMZ/cFcQi0W2AIHPYEMH/C95J2r4XbHMRdYXpovpOoT5Ca78gsCAwEAAQ==",
+        "keyDetails": "PKCS1_RSA_PKCS1V5",
+        "validFor": {
+          "start": "2021-03-14T00:00:00Z",
+          "end": "2022-07-31T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "G3wUKk6ZK6ffHh/FdCRUE2wVekyzHEEIpSG4savnv0w="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/2022",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh99xuRi6slBFd8VUJoK/rLigy4bYeSYWO/fE6Br7r0D8NpMI94+A63LR/WvLxpUUGBpY8IJA3iU2telag5CRpA==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-07-01T00:00:00Z",
+          "end": "2022-07-31T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "++JKOMQt7SJ3ynUHnCfnDhcKP8/58J4TueMqXuk3HmA="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/2022-2",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8gEDKNme8AnXuPBgHjrtXdS6miHqc24CRblNEOFpiJRngeq8Ko73Y+K18yRYVf1DXD4AVLwvKyzdNdl5n0jUSQ==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-07-01T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "KzC83GiIyeLh2CYpXnQfSDkxlgLynDPLXkNA/rKshno="
+      }
+    }
+  ],
+  "timestampAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore-tsa-selfsigned"
+      },
+      "uri": "https://timestamp.sigstage.dev/api/v1/timestamp",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICDzCCAZagAwIBAgIUCjWhBmHV4kFzxomWp/J98n4DfKcwCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTAzMjgwOTE0MDZaFw0zNTAzMjYwODE0MDZaMC4xFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEVMBMGA1UEAxMMc2lnc3RvcmUtdHNhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEx1v5F3HpD9egHuknpBFlRz7QBRDJu4aeVzt9zJLRY0lvmx1lF7WBM2c9AN8ZGPQsmDqHlJN2R/7+RxLkvlLzkc19IOx38t7mGGEcB7agUDdCF/Ky3RTLSK0Xo/0AgHQdo2owaDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKj8ZPYo3i7mO3NPVIxSxOGc3VOlMB8GA1UdIwQYMBaAFDsgRlletTJNRzDObmPuc3RH8gR9MBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMAoGCCqGSM49BAMDA2cAMGQCMESvVS6GGtF33+J19TfwENWJXjRv4i0/HQFwLUSkX6TfV7g0nG8VnqNHJLvEpAtOjQIwUD3uywTXorQP1DgbV09rF9Yen+CEqs/iEpieJWPst280SSOZ5Na+dyPVk9/8SFk6"
+          },
+          {
+            "rawBytes": "MIIB9zCCAXygAwIBAgIUCPExEFKiQh0dP4sp5ltmSYSSkFUwCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTAzMjgwOTE0MDZaFw0zNTAzMjYwODE0MDZaMDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATt0tIDWyo4ARfL9BaSo0W5bJQEbKJTU/u7llvdjSI5aTkOAJa8tixn2+LEfPG4dMFdsMPtsIuU1qn2OqFiuMk6vHv/c+az25RQVY1oo50iMb0jIL3N4FgwhPFpZnCbQPOjRTBDMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ7IEZZXrUyTUcwzm5j7nN0R/IEfTAKBggqhkjOPQQDAwNpADBmAjEA2MI1VXgbf3dUOSc95hSRypBKOab18eh2xzQtxUsHvWeY+1iFgyMluUuNR6taoSmFAjEA31m2czguZhKYX+4JSKu5pRYhBTXAd8KKQ3xdPRX/qCaLvT2qJAEQ1YQM3EJRrtI7"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2025-04-09T00:00:00Z"
+      }
+    }
+  ]
+}

--- a/test/client.py
+++ b/test/client.py
@@ -180,7 +180,7 @@ class SigstoreClient:
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", materials.trusted_root])
         if getattr(materials, "signing_config", None) is not None:
-            args.extend(["--signing_config", materials.signing_config])
+            args.extend(["--signing-config", materials.signing_config])
 
         self.run(*args)
 

--- a/test/client.py
+++ b/test/client.py
@@ -64,6 +64,7 @@ class BundleMaterials(VerificationMaterials):
 
     bundle: Path
     trusted_root: Path
+    signing_config: Path
 
     @classmethod
     def from_path(cls, bundle: Path) -> BundleMaterials:
@@ -176,6 +177,10 @@ class SigstoreClient:
                 artifact,
             ]
         )
+        if getattr(materials, "trusted_root", None) is not None:
+            args.extend(["--trusted-root", materials.trusted_root])
+        if getattr(materials, "signing_config", None) is not None:
+            args.extend(["--signing_config", materials.signing_config])
 
         self.run(*args)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -173,6 +173,14 @@ def client(pytestconfig, identity_token):
 
 
 @pytest.fixture
+def project_root(request) -> Path:
+    """
+    Returns the repository root directory.
+    """
+    return request.config.rootpath
+
+
+@pytest.fixture
 def make_materials_by_type() -> _MakeMaterialsByType:
     """
     Returns a function that constructs the requested subclass of
@@ -237,14 +245,14 @@ def verify_bundle(request, client) -> _VerifyBundle:
 
 
 @pytest.fixture(autouse=True)
-def workspace():
+def workspace(project_root: Path):
     """
     Create a temporary workspace directory to perform the test in.
     """
     workspace = tempfile.TemporaryDirectory()
 
     # Move entire contents of artifacts directory into workspace
-    assets_dir = Path(__file__).parent.parent / "test" / "assets"
+    assets_dir = project_root / "test" / "assets"
     shutil.copytree(assets_dir, workspace.name, dirs_exist_ok=True)
 
     # Now change the current working directory to our workspace

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import enum
-from fnmatch import fnmatch
 import functools
 import hashlib
 import json
@@ -11,6 +10,7 @@ import time
 from base64 import b64decode
 from collections.abc import Callable
 from datetime import datetime, timedelta
+from fnmatch import fnmatch
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TypeVar
@@ -264,7 +264,6 @@ def workspace(project_root: Path):
 
 @pytest.fixture(autouse=True)
 def conformance_xfail(request):
-
     if any([fnmatch(request.node.name, xfail_pattern) for xfail_pattern in _XFAIL_LIST]):
         request.node.add_marker(pytest.mark.xfail(reason="skipped by suite runner", strict=True))
 

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -88,6 +88,7 @@ def test_sign_does_not_produce_root(
         except x509.ExtensionNotFound:
             pass
 
+
 @pytest.mark.signing
 def test_sign_verify_rekor2(
     client: SigstoreClient,
@@ -120,12 +121,9 @@ def test_sign_verify_rekor2(
     # Use selftest client verify to assert that the bundle is correctly formed
     # (contains a valid TSA timestamp etc)
     selftest_client = SigstoreClient(
-        project_root / "sigstore-python-conformance",
-        client.identity_token,
-        client.staging
+        str(project_root / "sigstore-python-conformance"), client.identity_token, client.staging
     )
     selftest_client.verify(materials, input_path)
-
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Contents:
* Add `--signing-config` (and `--trusted-root`) to the client-under-test CLI when signing
* Make selftest client compatible with the new options
* Add a test that verifies clients capability to sign with rekor2 using the new flags

Background:
* We don't really want to use .e.g. `--staging` to test for specific results since we know the expected result changes over time (e.g. recommended tlog to use changes from rekor1 to rekor2)
* Instead we want to provide a specific signingconfig and trustedroot so we know the expected result -- the downside of this is that the services themselves may be turned offline at some point: this signingconfig and trustedroot needs to be updated at that point
* verifying the resulting bundle with the selftest client should mean that the bundle is good (because we know the selftest-client passes the verification tests). Running only the clients own verification tests could be problematic (imagine a client that hasn't yet implemented TSA signing or verification -- the signing test for rekor2 could then pass even if there was no timestamp in the bundle)
