### PR TITLE
action setup: Install selftest client as well

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,4 +58,5 @@ runs:
         GHA_SIGSTORE_CONFORMANCE_SKIP_SIGNING: "${{ inputs.skip-signing }}"
         GHA_SIGSTORE_CONFORMANCE_SKIP_CPYTHON_RELEASE_TESTS: "${{ inputs.skip-cpython-release-tests }}"
         GHA_SIGSTORE_CONFORMANCE_XFAIL: "${{ inputs.xfail }}"
+        GHA_SIGSTORE_CONFORMANCE_SELFTEST_BIN: "${{ github.workspace }}/sigstore-conformance-selftest-env/bin/sigstore"
       shell: bash

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -28,5 +28,10 @@ min_vers=$(cut -d '.' -f2 <<< "${vers}")
 
 [[ "${maj_vers}" == "3" && "${min_vers}" -ge 7 ]] || die "Bad Python version: ${vers}"
 
+# Install test suite
 python3 -m venv sigstore-conformance-env
 ./sigstore-conformance-env/bin/python -m pip install --requirement "${GITHUB_ACTION_PATH}/requirements.txt"
+
+# Signing test uses selftest client to verify the bundle: install selftest client as well
+python3 -m venv sigstore-conformance-selftest-env
+./sigstore-conformance-selftest-env/bin/python -m pip install --requirement "${GITHUB_ACTION_PATH}/selftest-requirements.txt"

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -52,8 +52,10 @@ ARG_REPLACEMENTS = {
 }
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-SIGSTORE_BINARY = os.path.join(script_dir, "selftest-env", "bin", "sigstore")
-
+SIGSTORE_BINARY = os.getenv(
+    "GHA_SIGSTORE_CONFORMANCE_SELFTEST_BIN",
+    os.path.join(script_dir, "selftest-env", "bin", "sigstore"),
+)
 if not os.path.exists(SIGSTORE_BINARY):
     exit(
         f"Error: sigstore binary not found in {SIGSTORE_BINARY}.\n"


### PR DESCRIPTION
The signing test now uses selftest client to verify the resulting bundle (with the idea that the client itself might not have good enough verification support -- but selftest client should be tested well).

Make sure the selftest client is installed during action setup.

Fixes #247.

---

