### PR TITLE
Use platformdirs for cache directory path

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,4 @@ pytest-subtests==0.15.0
 requests==2.32.5
 cryptography==46.0.3
 sigstore-protobuf-specs==0.5.0
+platformdirs==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -449,6 +449,10 @@ packaging==25.0 \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
     --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
     # via pytest
+platformdirs==4.4.0 \
+    --hash=sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85 \
+    --hash=sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf
+    # via -r requirements.in
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,7 @@ from tempfile import TemporaryDirectory
 from typing import TypeVar
 from urllib import parse
 
+import platformdirs
 import pytest
 
 from .client import (
@@ -296,7 +297,7 @@ def _client_config(project_root: Path, staging: bool) -> tuple[Path, Path]:
     subprocess.run(cmd, check=True)
 
     # then find files in sigstore-python cache
-    cache_dir = Path.home() / ".cache" / "sigstore-python" / "tuf" / repo
+    cache_dir = platformdirs.user_cache_path("sigstore-python") / "tuf" / repo
     tr = cache_dir / "trusted_root.json"
     sc = cache_dir / "signing_config.v0.2.json"
     assert tr.exists()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change replaces the hardcoded cache directory path used for the `sigstore-python` cache with a path dynamically generated by `platformdirs` to accommodate various operating systems.