### PR TITLE
dependabot: Update indirect deps as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,25 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    cooldown:
+       default-days: 7
+    allow:
+      - dependency-type: "all"
+    groups:
+      python-minor-and-patch-updates:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    cooldown:
+       default-days: 7
     groups:
       actions:
         patterns:


### PR DESCRIPTION
This is likely to increase the maintenance churn here but I think the alternative is that some of our dependencies will be very stale over time.

* Try to get dependabot to upgrade indirect deps
* Group minor and patch updates to minimize number of PRs
* Make schedule weekly instead of monthly so the updates are not massive
* Set cooldown as a best practice

