### PR TITLE
workflows: Set permissions in publish-report

### DIFF
--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fetch-results:
     name: Fetch ${{ matrix.name }} results


### PR DESCRIPTION
This should silence a GitHub code scanning alert. The actual publish needs some more permissions but those are given at the job level
