### PR TITLE
workflows: Add sigstore-rust to client conformance report

### DIFF
--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -34,6 +34,9 @@ jobs:
           - name: sigstore-ruby
             repo: sigstore/sigstore-ruby
             workflow: ci.yml
+          - name: sigstore-rust
+            repo: prefix-dev/sigstore-rust
+            workflow: ci.yml
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
sigstore-rust should appear in https://sigstore.github.io/sigstore-conformance/  on the next run (either manual or daily)

@wolfv let me know if you would rather not be listed yet.