### PR TITLE
Make the selftest more contained

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,7 +38,7 @@ jobs:
       - name: conformance test sigstore-python
         uses: ./
         with:
-          entrypoint: ${{ github.workspace }}/sigstore-python-conformance
+          entrypoint: ${{ github.workspace }}/selftest-client
           skip-cpython-release-tests: ${{ matrix.skip-cpython-release-tests }}
           environment: ${{ matrix.sigstore-infra }}
           xfail: "test_verify*-intoto-with-custom-trust-root] test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ client-under-test [CLI protocol](docs/cli_protocol.md).
               environment: staging
     ```
 
-See [sigstore-python conformance test](https://github.com/sigstore/sigstore-python/blob/main/.github/workflows/conformance.yml)
+See [selftest workflow](https://github.com/sigstore/sigstore-python/blob/main/.github/workflows/conformance.yml)
 for a complete example.
 
 ### `sigstore/sigstore-conformance` action inputs
@@ -111,14 +111,14 @@ The test suite can be configured with
 (env) $ pytest -v --entrypoint=$SIGSTORE_CLIENT --skip-signing
 ```
 
-Following example runs the test suite with the included sigstore-python-conformance client script:
+Following example runs the test suite with the included selftest client script:
 ```sh
 (env) $ # run all tests
 (env) $ GHA_SIGSTORE_CONFORMANCE_XFAIL="test_verify*-intoto-with-custom-trust-root] test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]" \
-    pytest -v --entrypoint=sigstore-python-conformance
+    pytest -v --entrypoint=selftest-client
 ...
 (env) $ # run single test
-(env) $ pytest -v --entrypoint=sigstore-python-conformance -k test_verify[DIGEST-happy-path]
+(env) $ pytest -v --entrypoint=selftest-client -k test_verify[DIGEST-happy-path]
 ...
 ```
 

--- a/selftest-client
+++ b/selftest-client
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This is the selftest-client for sigstore-conformance test suite
+# It is a wrapper to call sigstore-python-conformance in the correct virtualenv
+
+BASEDIR=$(dirname "$0")
+
+if [ ! -f "$BASEDIR/selftest-env/bin/python" ]; then
+    echo "selftest-env virtualenv not found, please run 'make selftest-env'" >&2
+    exit 1
+fi
+
+$BASEDIR/selftest-env/bin/python $BASEDIR/sigstore-python-conformance $@

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -287,10 +287,10 @@ def _client_config(project_root: Path, staging: bool) -> tuple[Path, Path]:
     This uses the internal selftest client feature 'update-trust-root'
     """
     if staging:
-        cmd = [str(project_root / "sigstore-python-conformance"), "--staging", "update-trust-root"]
+        cmd = [str(project_root / "selftest-client"), "--staging", "update-trust-root"]
         repo = parse.quote("https://tuf-repo-cdn.sigstage.dev", safe="")
     else:
-        cmd = [str(project_root / "sigstore-python-conformance"), "update-trust-root"]
+        cmd = [str(project_root / "selftest-client"), "update-trust-root"]
         repo = parse.quote("https://tuf-repo-cdn.sigstore.dev", safe="")
 
     # run the selftest client to update files in sigstore-python cache

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -126,7 +126,7 @@ def test_sign_verify_rekor2(
     # Use selftest client verify to assert that the bundle is correctly formed
     # (contains a valid TSA timestamp etc)
     selftest_client = SigstoreClient(
-        str(project_root / "sigstore-python-conformance"), client.identity_token, client.staging
+        str(project_root / "selftest-client"), client.identity_token, client.staging
     )
     selftest_client.verify(materials, input_path)
 


### PR DESCRIPTION
This is an attempt to help out with #325

* We want to use some sigstore-python imports in the selftest code itself (instead of just calling the CLI)
* Handle the virtualenv with another layer of wrapper: The selftest is now the shell script that runs the python files using the virtualenv

This allows using sigstore-python imports in sigstore-python-conformance

