### PR TITLE
Make sure selftest env is found when running action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
         GHA_SIGSTORE_CONFORMANCE_CLIENT_SHA: "${{ github.sha }}"
         GHA_SIGSTORE_CONFORMANCE_CLIENT_SHA_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
         GHA_SIGSTORE_CONFORMANCE_WORKFLOW_RUN: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        GHA_SIGSTORE_CONFORMANCE_SELFTEST_BIN: "${{ github.workspace }}/sigstore-conformance-selftest-env/bin/sigstore"
+        GHA_SIGSTORE_CONFORMANCE_SELFTEST_ENV: "${{ github.workspace }}/sigstore-conformance-selftest-env/"
       shell: bash
 
     - name: Upload conformance result

--- a/selftest-client
+++ b/selftest-client
@@ -4,10 +4,11 @@
 # It is a wrapper to call sigstore-python-conformance in the correct virtualenv
 
 BASEDIR=$(dirname "$0")
+VENV_PATH="${GHA_SIGSTORE_CONFORMANCE_SELFTEST_ENV:-$BASEDIR/selftest-env}"
 
-if [ ! -f "$BASEDIR/selftest-env/bin/python" ]; then
-    echo "selftest-env virtualenv not found, please run 'make selftest-env'" >&2
+if [ ! -f "$VENV_PATH/bin/python" ]; then
+    echo "self-test virtualenv not found, please run 'make selftest-env'" >&2
     exit 1
 fi
 
-$BASEDIR/selftest-env/bin/python $BASEDIR/sigstore-python-conformance $@
+"$VENV_PATH/bin/python" "$BASEDIR/sigstore-python-conformance" "$@"

--- a/sigstore-python-conformance
+++ b/sigstore-python-conformance
@@ -3,7 +3,8 @@
 """
 A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `sigstore-python`.
 
-This wrapper expects to find sigstore-python binary installed in selftest-env/bin/sigstore
+This wrapper expects to find sigstore-python binary in the path, and sigstore modules importable:
+See selftest-client for how this is managed.
 """
 
 import json
@@ -51,17 +52,6 @@ ARG_REPLACEMENTS = {
     "--certificate-oidc-issuer": "--cert-oidc-issuer",
 }
 
-script_dir = os.path.dirname(os.path.realpath(__file__))
-SIGSTORE_BINARY = os.getenv(
-    "GHA_SIGSTORE_CONFORMANCE_SELFTEST_BIN",
-    os.path.join(script_dir, "selftest-env", "bin", "sigstore"),
-)
-if not os.path.exists(SIGSTORE_BINARY):
-    exit(
-        f"Error: sigstore binary not found in {SIGSTORE_BINARY}.\n"
-        "Has the environment been initialized with 'make dev'?"
-    )
-
 # Trim the script name.
 fixed_args = sys.argv[1:]
 
@@ -71,7 +61,7 @@ if subcmd in SUBCMD_REPLACEMENTS:
     fixed_args[0] = SUBCMD_REPLACEMENTS[subcmd]
 
 # Build base command with optional staging argument
-command = ["sigstore"]
+command = [sys.executable, "-m",  "sigstore"]
 if "--staging" in fixed_args:
     command.append("--staging")
     fixed_args.remove("--staging")
@@ -127,4 +117,4 @@ with NamedTemporaryFile(mode="wt") as temp_file:
     # Replace incompatible flags.
     command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
 
-    os.execvp(SIGSTORE_BINARY, command)
+    os.execv(sys.executable, command)


### PR DESCRIPTION
My recent selftest containment change broke this: 
* the issue only comes up when action is used with "uses: sigstore/sigstore-conformance" so our CI did not notice
* sigstore-python-conformance script now needs the selftest env (instead of only the sigstore-python that it executes needing the env)

Fix by making sure the action correctly provides the selftest env path that it has setup (and not just a path to sigstore executable).

I tested this with my sigstore-python fork, seems to work

Fixes #331 