### PR TITLE
cli_protocol.md: Mention sign-bundle input type in in-toto case

### DIFF
--- a/docs/cli_protocol.md
+++ b/docs/cli_protocol.md
@@ -43,7 +43,7 @@ ${ENTRYPOINT} sign-bundle [--staging] [--in-toto] --identity-token TOKEN --bundl
 | `--bundle FILE` | The path to write the bundle to |
 | `--trusted-root TRUSTROOT` | Optional path to a custom trusted root to use to verify the bundle |
 | `--signing-config SIGNINGCONFIG` | Optional path to a custom signing config to use when signing |
-| `FILE` | The artifact to sign |
+| `FILE` | The artifact to sign. When `--in-toto` is used, the in-toto statement to sign |
 
 ### Verify
 


### PR DESCRIPTION
Clarify that FILE is an intoto statement when --in-toto is used

CC @aaronlew02 