### PR TITLE
Add staging marker to sign+verify tests

### DIFF
--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -54,6 +54,7 @@ def test_verify(
 
 
 @pytest.mark.signing
+@pytest.mark.staging
 def test_sign_does_not_produce_root(
     client: SigstoreClient,
     make_materials_by_type: _MakeMaterialsByType,
@@ -203,6 +204,7 @@ def test_verify_cpython_release_bundles(subtests, client):
 
 
 @pytest.mark.signing
+@pytest.mark.staging
 def test_sign_verify_dsse(
     client: SigstoreClient,
     make_materials_by_type: _MakeMaterialsByType,


### PR DESCRIPTION
This makes these two tests run when "environment=staging"

The separate "staging" test run is a little useless (see #279 for future ideas) but this makes it a little more comprehensive: run all of the generic sign+verify tests on staging too.

CC @aaronlew02 @loosebazooka 