### PR TITLE
Add statement attribute to BundleMaterials for DSSE signing

### DIFF
--- a/test/assets/bundle-verify/README.md
+++ b/test/assets/bundle-verify/README.md
@@ -7,7 +7,7 @@ Each subdirectory is used to parametrize test_verify():
   * `bundle.sigstore.json`: The signature bundle
   * `README`: Explanation of the test: why it should fail/succeed
 * Directory may optionally contain
-  * `artifact`: The signed artifact (if not provided, "a.txt" from the parent directory is used)
+  * `artifact`: The signed artifact. For DSSE (in-toto) envelopes, this file represents the subject of the attestation. (If not provided, "a.txt" from the parent directory is used)
   * `identity`: file contents are the signing identity (if not provided, "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" is used)
   * `issuer`: file contents are the signing identity issuer (if not provided, "https://token.actions.githubusercontent.com" is used)
   * `key.pub`: The PEM-encoded public key used for verification. When this file is present, verification will be attempted with the key instead of OIDC

--- a/test/client.py
+++ b/test/client.py
@@ -70,7 +70,6 @@ class BundleMaterials(VerificationMaterials):
     signing_config: Path
     artifact: Path
     statement: Path | None
-    subject: Path | None
     key: Path
     identity: str
     issuer: str
@@ -314,17 +313,11 @@ class SigstoreClient:
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", str(materials.trusted_root)])
 
-        subject = getattr(materials, "subject", None)
-        if subject is not None:
-            artifact_to_verify = subject
-        else:
-            artifact_to_verify = materials.artifact
-
         if digest:
-            artifact = artifact_to_verify.read_bytes()
+            artifact = materials.artifact.read_bytes()
             digest_str = f"sha256:{hashlib.sha256(artifact).hexdigest()}"
             args.append(digest_str)
         else:
-            args.append(str(artifact_to_verify))
+            args.append(str(materials.artifact))
 
         return args

--- a/test/client.py
+++ b/test/client.py
@@ -69,6 +69,8 @@ class BundleMaterials(VerificationMaterials):
     trusted_root: Path
     signing_config: Path
     artifact: Path
+    statement: Path | None
+    subject: Path | None
     key: Path
     identity: str
     issuer: str
@@ -245,7 +247,9 @@ class SigstoreClient:
         if getattr(materials, "signing_config", None) is not None:
             args.extend(["--signing-config", str(materials.signing_config)])
 
-        self.run(*args, str(materials.artifact))
+        artifact_to_sign = materials.statement if dsse else materials.artifact
+        assert artifact_to_sign is not None
+        self.run(*args, str(artifact_to_sign))
 
         # Set the used signing identity and issuer on verification materials:
         # This way a later verify() call will know what to expect
@@ -253,7 +257,7 @@ class SigstoreClient:
         materials.issuer = self.issuer
 
     @singledispatchmethod
-    def verify(self, materials: VerificationMaterials) -> None:
+    def verify(self, materials: VerificationMaterials, dsse: bool = False) -> None:
         """
         Verify an artifact with the Sigstore client. Dispatches to
          `_verify_{artifact|digest}_for_bundle` when given `BundleMaterials`.
@@ -265,26 +269,26 @@ class SigstoreClient:
         raise NotImplementedError(f"Cannot verify with {type(materials)}")
 
     @singledispatchmethod
-    def verify_digest(self, materials: VerificationMaterials) -> None:
+    def verify_digest(self, materials: VerificationMaterials, dsse: bool = False) -> None:
         raise NotImplementedError(f"Cannot verify with {type(materials)}")
 
     @verify_digest.register
-    def _verify_digest_for_bundle(self, materials: BundleMaterials) -> None:
-        args = self.build_verify_args(materials, digest=True)
+    def _verify_digest_for_bundle(self, materials: BundleMaterials, dsse: bool = False) -> None:
+        args = self.build_verify_args(materials, digest=True, dsse=dsse)
         self.run(*args)
 
     @verify.register
-    def _verify_artifact_for_bundle(self, materials: BundleMaterials) -> None:
+    def _verify_artifact_for_bundle(self, materials: BundleMaterials, dsse: bool = False) -> None:
         """
         Verify an artifact given a bundle with the Sigstore client.
 
         This is an overload of `verify` for the bundle flow and should not be called
         directly.
         """
-        args = self.build_verify_args(materials)
+        args = self.build_verify_args(materials, dsse=dsse)
         self.run(*args)
 
-    def build_verify_args(self, materials: BundleMaterials, digest: bool = False) -> list[str]:
+    def build_verify_args(self, materials: BundleMaterials, digest: bool = False, dsse: bool = False) -> list[str]:
         args = ["verify-bundle"]
         if self.staging:
             args.append("--staging")
@@ -306,11 +310,14 @@ class SigstoreClient:
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", str(materials.trusted_root)])
 
+        artifact_to_verify = materials.subject if dsse else materials.artifact
+        assert artifact_to_verify is not None
+
         if digest:
-            artifact = materials.artifact.read_bytes()
+            artifact = artifact_to_verify.read_bytes()
             digest_str = f"sha256:{hashlib.sha256(artifact).hexdigest()}"
             args.append(digest_str)
         else:
-            args.append(str(materials.artifact))
+            args.append(str(artifact_to_verify))
 
         return args

--- a/test/client.py
+++ b/test/client.py
@@ -201,7 +201,7 @@ class SigstoreClient:
             raise ClientUnexpectedSuccess(msg)
 
     @singledispatchmethod
-    def sign(self, materials: VerificationMaterials, dsse: bool = False) -> None:
+    def sign(self, materials: VerificationMaterials) -> None:
         """
         Sign an artifact with the Sigstore client. Dispatches to `_sign_for_bundle` when
         given `BundleMaterials`.
@@ -216,7 +216,7 @@ class SigstoreClient:
         raise NotImplementedError(f"Cannot sign with {type(materials)}")
 
     @sign.register
-    def _sign_for_bundle(self, materials: BundleMaterials, dsse: bool = False) -> None:
+    def _sign_for_bundle(self, materials: BundleMaterials) -> None:
         """
         Sign an artifact with the Sigstore client, producing a bundle.
 
@@ -232,8 +232,14 @@ class SigstoreClient:
         args = ["sign-bundle"]
         if self.staging:
             args.append("--staging")
-        if dsse:
+
+        statement = getattr(materials, "statement", None)
+        if statement is not None:
             args.append("--in-toto")
+            artifact_to_sign = statement
+        else:
+            artifact_to_sign = materials.artifact
+
         args.extend(
             [
                 "--identity-token",
@@ -247,8 +253,6 @@ class SigstoreClient:
         if getattr(materials, "signing_config", None) is not None:
             args.extend(["--signing-config", str(materials.signing_config)])
 
-        artifact_to_sign = materials.statement if dsse else materials.artifact
-        assert artifact_to_sign is not None
         self.run(*args, str(artifact_to_sign))
 
         # Set the used signing identity and issuer on verification materials:
@@ -257,7 +261,7 @@ class SigstoreClient:
         materials.issuer = self.issuer
 
     @singledispatchmethod
-    def verify(self, materials: VerificationMaterials, dsse: bool = False) -> None:
+    def verify(self, materials: VerificationMaterials) -> None:
         """
         Verify an artifact with the Sigstore client. Dispatches to
          `_verify_{artifact|digest}_for_bundle` when given `BundleMaterials`.
@@ -269,26 +273,26 @@ class SigstoreClient:
         raise NotImplementedError(f"Cannot verify with {type(materials)}")
 
     @singledispatchmethod
-    def verify_digest(self, materials: VerificationMaterials, dsse: bool = False) -> None:
+    def verify_digest(self, materials: VerificationMaterials) -> None:
         raise NotImplementedError(f"Cannot verify with {type(materials)}")
 
     @verify_digest.register
-    def _verify_digest_for_bundle(self, materials: BundleMaterials, dsse: bool = False) -> None:
-        args = self.build_verify_args(materials, digest=True, dsse=dsse)
+    def _verify_digest_for_bundle(self, materials: BundleMaterials) -> None:
+        args = self.build_verify_args(materials, digest=True)
         self.run(*args)
 
     @verify.register
-    def _verify_artifact_for_bundle(self, materials: BundleMaterials, dsse: bool = False) -> None:
+    def _verify_artifact_for_bundle(self, materials: BundleMaterials) -> None:
         """
         Verify an artifact given a bundle with the Sigstore client.
 
         This is an overload of `verify` for the bundle flow and should not be called
         directly.
         """
-        args = self.build_verify_args(materials, dsse=dsse)
+        args = self.build_verify_args(materials)
         self.run(*args)
 
-    def build_verify_args(self, materials: BundleMaterials, digest: bool = False, dsse: bool = False) -> list[str]:
+    def build_verify_args(self, materials: BundleMaterials, digest: bool = False) -> list[str]:
         args = ["verify-bundle"]
         if self.staging:
             args.append("--staging")
@@ -310,8 +314,11 @@ class SigstoreClient:
         if getattr(materials, "trusted_root", None) is not None:
             args.extend(["--trusted-root", str(materials.trusted_root)])
 
-        artifact_to_verify = materials.subject if dsse else materials.artifact
-        assert artifact_to_verify is not None
+        subject = getattr(materials, "subject", None)
+        if subject is not None:
+            artifact_to_verify = subject
+        else:
+            artifact_to_verify = materials.artifact
 
         if digest:
             artifact = artifact_to_verify.read_bytes()

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -205,8 +205,8 @@ def test_sign_verify_dsse(
     materials.statement = materials.artifact
     materials.subject = Path("a.txt")
 
-    # Sign for our input with DSSE enabled.
-    client.sign(materials, dsse=True)
+    # Sign for our input.
+    client.sign(materials)
 
     # Parse the output bundle.
     bundle_contents = materials.bundle.read_bytes()
@@ -219,11 +219,11 @@ def test_sign_verify_dsse(
     # Ensure DSSE envelope payload matches the statement
     assert bundle.dsse_envelope.payload == materials.statement.read_bytes()
 
-    # Verify the bundle with DSSE enabled
-    client.verify(materials, dsse=True)
+    # Verify the bundle.
+    client.verify(materials)
 
     # Use selftest client verify to assert that the bundle is correctly formed
     selftest_client = SigstoreClient(
         str(project_root / "selftest-client"), client.identity_token, client.staging
     )
-    selftest_client.verify(materials, dsse=True)
+    selftest_client.verify(materials)

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -201,6 +201,10 @@ def test_sign_verify_dsse(
     materials = make_materials_by_type("statement.json", BundleMaterials)
     assert not materials.exists()
 
+    # Separate statement (for signing) and subject (for verification)
+    materials.statement = materials.artifact
+    materials.subject = Path("a.txt")
+
     # Sign for our input with DSSE enabled.
     client.sign(materials, dsse=True)
 
@@ -213,17 +217,13 @@ def test_sign_verify_dsse(
     assert not bundle.is_set("message_signature")
 
     # Ensure DSSE envelope payload matches the statement
-    assert bundle.dsse_envelope.payload == materials.artifact.read_bytes()
+    assert bundle.dsse_envelope.payload == materials.statement.read_bytes()
 
-    # TODO: separate subject and statement in dsse case:
-    # "artifact" is a statement when signing, but a subject when verifying
-    materials.artifact = Path("a.txt")
-
-    # Verify the bundle
-    client.verify(materials)
+    # Verify the bundle with DSSE enabled
+    client.verify(materials, dsse=True)
 
     # Use selftest client verify to assert that the bundle is correctly formed
     selftest_client = SigstoreClient(
         str(project_root / "selftest-client"), client.identity_token, client.staging
     )
-    selftest_client.verify(materials)
+    selftest_client.verify(materials, dsse=True)

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -203,7 +203,7 @@ def test_sign_verify_dsse(
 
     # Separate statement (for signing) and subject (for verification)
     materials.statement = materials.artifact
-    materials.subject = Path("a.txt")
+    materials.artifact = Path("a.txt")
 
     # Sign for our input.
     client.sign(materials)
@@ -219,7 +219,7 @@ def test_sign_verify_dsse(
     # Ensure DSSE envelope payload matches the statement
     assert bundle.dsse_envelope.payload == materials.statement.read_bytes()
 
-    # Verify the bundle.
+    # Verify the bundle
     client.verify(materials)
 
     # Use selftest client verify to assert that the bundle is correctly formed


### PR DESCRIPTION
#### Summary

This change adds a `statement` path attribute to `BundleMaterials` to represent the statement used for signing of DSSE attestations.

Previously, `BundleMaterials` contained only a single `artifact` attribute, which, for DSSE attestations, was populated with a statement for signing and then swapped with a subject for verification. Now, the DSSE signing and verification test populates the new `statement` field with the statement and the `artifact` field with the subject, and `sign` uses the former in the DSSE case.